### PR TITLE
Include krmllib.h in eurydice_glue.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 CHARON_HOME 	?= $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/../charon
+KRML_HOME 		?= $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/../karamel
 EURYDICE	= ./eurydice $(EURYDICE_FLAGS)
 
 CHARON_TEST_FILES	= array
@@ -10,7 +11,7 @@ all:
 	@ocamlfind list | grep -q krml || test -L lib/krml || echo "⚠️⚠️⚠️ krml not found; we suggest cd lib && ln -s path/to/karamel/lib krml"
 	dune build && ln -sf _build/default/bin/main.exe eurydice
 
-CFLAGS		:= -Wall -Werror -Wno-unused-variable $(CFLAGS)
+CFLAGS		:= -Wall -Werror -Wno-unused-variable $(CFLAGS) -I$(KRML_HOME)/include
 
 test: $(addprefix charon-test-,$(CHARON_TEST_FILES)) $(addprefix test-,$(TEST_DIRS))
 

--- a/include/eurydice_glue.h
+++ b/include/eurydice_glue.h
@@ -1,6 +1,15 @@
 #pragma once
 
-#include "krmllib.h"
+#include <inttypes.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "krml/lowstar_endianness.h"
+#include "krml/internal/target.h"
+
+#define LowStar_Ignore_ignore(e, t) ((void)e)
 
 // SLICES, ARRAYS, ETC.
 


### PR DESCRIPTION
Can we include `krmllib.h` instead in the glue?
This breaks tests here like this because the include is missing. But adding the include path should fix that.

wdyt?