### PR TITLE
Drop core_num__u32_8__BITS eurydice_glue.h

### DIFF
--- a/include/eurydice_glue.h
+++ b/include/eurydice_glue.h
@@ -87,8 +87,6 @@ static inline void core_ops_arith__i32_319__add_assign(int32_t *x0, int32_t *x1)
 static inline uint8_t Eurydice_bitand_pv_u8(uint8_t *p, uint8_t v) { return (*p) & v; }
 static inline uint8_t Eurydice_shr_pv_u8(uint8_t *p, int32_t v) { return (*p) >> v; }
 
-static uint32_t core_num__u32_8__BITS = 32;
-
 // ITERATORS
 
 #define core_num_nonzero_NonZeroUsize size_t


### PR DESCRIPTION
Drop `core_num__u32_8__BITS`. It doesn't work. It needs to be `#define`d in the header file manually for now.