### PR TITLE
ci: use charon#138 to fix the CI

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -11,15 +11,16 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1713541951,
-        "narHash": "sha256-Jz+uVa5kJkAqsOJt2Ww1FF8FngKuXNYuYMPJS7slVY0=",
+        "lastModified": 1713795346,
+        "narHash": "sha256-owF21YwJJDHWLpyzwsodIP6AuEoUxva01c/VdspUL7g=",
         "owner": "AeneasVerif",
         "repo": "charon",
-        "rev": "64551ed9ce41beb7842cbc075cbb058b626bc259",
+        "rev": "2dd9c655208f7c9d696e9c370f4836e11e846c8b",
         "type": "github"
       },
       "original": {
         "owner": "AeneasVerif",
+        "ref": "fix-rustup-detection",
         "repo": "charon",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
 
     nixpkgs.follows = "karamel/nixpkgs";
 
-    charon.url = "github:AeneasVerif/charon";
+    charon.url = "github:AeneasVerif/charon/fix-rustup-detection";
     charon.inputs.nixpkgs.follows = "nixpkgs";
   };
   outputs = {
@@ -61,8 +61,7 @@
               buildInputs = [charon.buildInputs eurydice];
               nativeBuildInputs = [charon.nativeBuildInputs fstar clang];
               buildPhase = ''
-                # we need to tell `charon` not to use `rustup`
-                export CHARON="${charon}/bin/charon --cargo-no-rust-version"
+                export CHARON="${charon}/bin/charon"
 
                 # setup CHARON_HOME: it is expected to be writtable, hence the `cp --no-preserve`
                 cp --no-preserve=mode,ownership -rf ${inputs.charon.sourceInfo.outPath} ./charon


### PR DESCRIPTION
My recent changes to charon broke your CI. https://github.com/AeneasVerif/charon/pull/138 fixes it but isn't merged yet. This PR points your CI at my charon branch to make it work again. Next time you want to bump charon, just remove the `/fix-rustup-detection` I added in `flake.nix`.