### PR TITLE
nix: add a dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,8 @@
 
           src = ./.;
 
+          OCAMLPARAM = "_,warn-error=+A"; # Turn all warnings into errors.
+
           nativeBuildInputs = [gnugrep];
 
           propagatedBuildInputs = [krml charon-ml ocamlPackages.terminal ocamlPackages.yaml];

--- a/flake.nix
+++ b/flake.nix
@@ -81,5 +81,16 @@
         version = self.rev or "dirty";
       };
       checks.default = packages.default.tests;
+      devShells.default = pkgs.mkShell {
+        packages = [
+          pkgs.ocamlPackages.ocaml
+          pkgs.ocamlPackages.ocamlformat
+          pkgs.ocamlPackages.menhir
+        ];
+
+        inputsFrom = [
+          self.packages.${system}.default
+        ];
+      };
     });
 }


### PR DESCRIPTION
This PR does two things:
- Adds a dev shell for nix users like me so we can easily develop on eurydice;
- ~Makes it so the nix builder (and thus the CI) reports warning as errors, because CI was missing errors like non-exhaustive matches. I set all warnings to be errors which might be a bit strong; we can tweak as needed.~