### PR TITLE
Simplify synchronization with Charon

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -13,3 +13,13 @@ jobs:
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Build and test
         run: nix flake check -L
+
+  check-charon-pin:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # deep clone in order to get access to other commits
+      - run: nix-shell -p jq --run ./scripts/ci-check-charon-pin.sh

--- a/Makefile
+++ b/Makefile
@@ -38,3 +38,8 @@ out/%:
 
 nix-magic:
 	nix flake update --extra-experimental-features nix-command --extra-experimental-features flakes
+
+# Updates `flake.lock` with the latest commit from our local charon clone (the one that is symlinked into `lib/charon`).
+.PHONY: update-charon-pin
+update-charon-pin:
+	nix-shell -p jq --run ./scripts/update-charon-pin.sh

--- a/scripts/ci-check-charon-pin.sh
+++ b/scripts/ci-check-charon-pin.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Checks that the charon pin:
+# - moves forward from the previous pin, to ensure we don't regress the Charon version;
+# - is merged into Charon.
+
+NEW_CHARON_PIN="$(cat flake.lock | jq -r .nodes.charon.locked.rev)"
+OLD_CHARON_PIN="$(git show origin/main:flake.lock | jq -r .nodes.charon.locked.rev)"
+echo "This PR updates the charon pin from $OLD_CHARON_PIN to $NEW_CHARON_PIN"
+
+git clone https://github.com/AeneasVerif/charon
+cd charon
+CHARON_MAIN="$(git rev-parse HEAD)"
+
+if ! git merge-base --is-ancestor "$OLD_CHARON_PIN" "$NEW_CHARON_PIN"; then
+    echo "Error: the new charon pin does not have the old one as its ancestor. The pin must only move forward."
+    exit 1
+fi
+
+if ! git merge-base --is-ancestor "$NEW_CHARON_PIN" "$CHARON_MAIN"; then
+    echo "Error: commit $NEW_CHARON_PIN is not merged into Charon."
+    exit 1
+fi

--- a/scripts/update-charon-pin.sh
+++ b/scripts/update-charon-pin.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+if ! which jq 2> /dev/null 1>&2; then
+    echo 'Error: command `jq` not found; please install it.'
+    exit 1
+fi
+
+CHARON_DIR=./lib/charon/..
+CHARON_BRANCH="$(git -C "$CHARON_DIR" rev-parse --abbrev-ref HEAD)"
+CHARON_COMMIT="$(git -C "$CHARON_DIR" rev-parse HEAD)"
+echo 'Taking the commit from your local charon directory. The charon branch is `'"$CHARON_BRANCH"'`'
+nix flake lock --extra-experimental-features nix-command --extra-experimental-features flakes --override-input charon "github:aeneasverif/charon/$CHARON_COMMIT"


### PR DESCRIPTION
I propose to copy the workflow we use in Aeneas to synchronize changes between Charon and Eurydice. The proposed workflow is as follows: when a PR is made to Charon that requires changes to Eurydice, we prepare the corresponding change to Eurydice, run `make update-charon-pin`, and submit a PR.

This will point the `flake.lock` at the right Charon branch, so the CI checks on the Eurydice side will be green. The exception is the new `check-charon-pin` CI check, which stays red until the Charon PR is merged. This is to avoid accidents where e.g. we rebase a branch and the `flake.lock` points to a commit that doesn't exist anymore. It also ensures we don't pick a charon commit that is older than before.

Once the Aeneas and Eurydice PRs are ready and green (with the exception of the `check-charon-pin` check), we can merge everything in any order.