### PR TITLE
Plenty of small changes for code quality

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,5 +1,5 @@
 profile = default
-version = 0.26.0
+version = 0.26.2
 margin = 100
 
 break-cases = fit-or-vertical

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ TEST_DIRS		= $(filter-out $(BROKEN_TESTS),$(subst test/,,$(shell find test -maxd
 all: format-check
 	@ocamlfind list | grep -q charon || test -L lib/charon || echo "⚠️⚠️⚠️ Charon not found; we suggest cd lib && ln -s path/to/charon-ml charon"
 	@ocamlfind list | grep -q krml || test -L lib/krml || echo "⚠️⚠️⚠️ krml not found; we suggest cd lib && ln -s path/to/karamel/lib krml"
+	$(MAKE) build
+
+.PHONY: build
+build:
 	dune build && ln -sf _build/default/bin/main.exe eurydice
 
 CFLAGS		:= -Wall -Werror -Wno-unused-variable $(CFLAGS) -I$(KRML_HOME)/include

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -82,7 +82,7 @@ Supported options:|}
       unroll_loops := !funroll_loops;
       static_header := [ Bundle.Prefix [ "core"; "convert" ]; Bundle.Prefix [ "core"; "num" ] ];
       Warn.parse_warn_error (!warn_error ^ "+8"));
-    Monomorphization.Gen.short_names := true);
+    Monomorphization.NameGen.short_names := true);
 
   (* Some logic for more precisely tracking readonly functions, so as to remove
      excessive uu__ variables. *)

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -109,9 +109,10 @@ Supported options:|}
            | "libcrux_intrinsics" :: _, _ -> ret_t <> TUnit
            | [ "Eurydice" ], "vec_len"
            | [ "Eurydice" ], "vec_index"
-           | [ "Eurydice" ], "array_to_slice"
+           | [ "Eurydice" ], "slice_index"
            | [ "Eurydice" ], "slice_subslice"
-           | "core" :: "num" :: _, ("rotate_left" | "from_le_bytes") -> true
+           | [ "Eurydice" ], "array_to_slice"
+           | "core" :: "num" :: _, ("rotate_left" | "from_le_bytes" | "wrapping_add") -> true
            | _ -> false)
         || Hashtbl.mem readonly_lids lid
         ||

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -81,7 +81,8 @@ Supported options:|}
       cxx_compat := true;
       unroll_loops := !funroll_loops;
       static_header := [ Bundle.Prefix [ "core"; "convert" ]; Bundle.Prefix [ "core"; "num" ] ];
-      Warn.parse_warn_error (!warn_error ^ "+8")));
+      Warn.parse_warn_error (!warn_error ^ "+8"));
+    Monomorphization.Gen.short_names := true);
 
   (* Some logic for more precisely tracking readonly functions, so as to remove
      excessive uu__ variables. *)

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -230,6 +230,7 @@ Supported options:|}
   let files = Krml.Simplify.fixup_hoist#visit_files () files in
   let files = Krml.Simplify.misc_cosmetic#visit_files () files in
   let files = Krml.Simplify.let_to_sequence#visit_files () files in
+  let files = Eurydice.Cleanup3.bonus_cleanups#visit_files () files in
   Eurydice.Logging.log "Phase2.8" "%a" pfiles files;
   (* Macros stemming from globals *)
   let files, macros = Eurydice.Cleanup2.build_macros files in

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -179,6 +179,7 @@ Supported options:|}
   if errors then
     fail __FILE__ __LINE__;
   Eurydice.Logging.log "Phase2.1" "%a" pfiles files;
+  let files = Eurydice.Cleanup2.improve_names files in
   let files = Krml.Monomorphization.functions files in
   let files = Krml.Monomorphization.datatypes files in
   let files =

--- a/flake.lock
+++ b/flake.lock
@@ -11,11 +11,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1721657726,
-        "narHash": "sha256-7J758sx+7AC2bzInrlaZLC1yn59UVR4kdlT8bvqkGmw=",
-        "owner": "aeneasverif",
+        "lastModified": 1721822368,
+        "narHash": "sha256-Al2McaTb/FBCs5AHp01G1sfinUEM7py9RNhoSzwRUfI=",
+        "owner": "AeneasVerif",
         "repo": "charon",
-        "rev": "ee335659fe378b51f04b6701632acbc56a205228",
+        "rev": "45b95e0f63cb830202c0b3ca00a341a3451a02ba",
         "type": "github"
       },
       "original": {
@@ -136,11 +136,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1721060146,
-        "narHash": "sha256-fiNawQcuBDF/YXNOvO1OnitF72YZC2vAWpFmQZ2x8nc=",
+        "lastModified": 1721552334,
+        "narHash": "sha256-FDfp4JquvP5e4obYdG7hpe5hwMOTxYwe4ArtNXKHvcY=",
         "owner": "FStarLang",
         "repo": "fstar",
-        "rev": "ecae05bd96c3c707835ec25585a0f7c1d2c1b932",
+        "rev": "e5cef6f266ece8a8b55ef4cd9b61cdf103520d38",
         "type": "github"
       },
       "original": {
@@ -155,11 +155,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1721060146,
-        "narHash": "sha256-fiNawQcuBDF/YXNOvO1OnitF72YZC2vAWpFmQZ2x8nc=",
+        "lastModified": 1721552334,
+        "narHash": "sha256-FDfp4JquvP5e4obYdG7hpe5hwMOTxYwe4ArtNXKHvcY=",
         "owner": "fstarlang",
         "repo": "fstar",
-        "rev": "ecae05bd96c3c707835ec25585a0f7c1d2c1b932",
+        "rev": "e5cef6f266ece8a8b55ef4cd9b61cdf103520d38",
         "type": "github"
       },
       "original": {
@@ -183,11 +183,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721075662,
-        "narHash": "sha256-/v67SLovnsBZ+KdT/ms9zMijREaeCGrf3HPMVS/X+G0=",
+        "lastModified": 1722627673,
+        "narHash": "sha256-rMfl/ecmz20OQTgx8QqdFKJZ7VUXOjVw4fsG2rNjf90=",
         "owner": "FStarLang",
         "repo": "karamel",
-        "rev": "65aab550cf3ba36d52ae6ad1ad962bb573406395",
+        "rev": "fc56fce6a58754766809845f88fc62063b2c6b92",
         "type": "github"
       },
       "original": {
@@ -246,11 +246,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721614891,
-        "narHash": "sha256-1yGOh8w/yhWAZ2NJR9N/shQ1tx2n9fmGe0XrDE00i9U=",
+        "lastModified": 1719368303,
+        "narHash": "sha256-vhkKOUs9eOZgcPrA6wMw7a7J48pEjVuhzQfitVwVv1g=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "424a759557ed4c01cf9dbbf79a714150d64a90ad",
+        "rev": "32415b22fd3b454e4a1385af64aa5cef9766ff4c",
         "type": "github"
       },
       "original": {

--- a/include/eurydice_glue.h
+++ b/include/eurydice_glue.h
@@ -70,6 +70,9 @@ typedef struct {
                  end) /* x is already at an array type, no need for cast */
 #define Eurydice_array_to_subslice(_arraylen, x, r, t, _, _ret_t)              \
   EURYDICE_SLICE((t *)x, r.start, r.end)
+// Same as above, variant for when start and end are statically known
+#define Eurydice_array_to_subslice2(x, start, end, t, _ret_t)                  \
+  EURYDICE_SLICE((t *)x, start, end)
 #define Eurydice_array_to_subslice_to(_size, x, r, t, _range_t, _ret_t)        \
   EURYDICE_SLICE((t *)x, 0, r)
 #define Eurydice_array_to_subslice_from(size, x, r, t, _range_t, _ret_t)       \

--- a/include/eurydice_glue.h
+++ b/include/eurydice_glue.h
@@ -57,6 +57,10 @@ typedef struct {
 #define Eurydice_slice_index(s, i, t, t_ptr_t, _ret_t) (((t_ptr_t)s.ptr)[i])
 #define Eurydice_slice_subslice(s, r, t, _, _ret_t)                            \
   EURYDICE_SLICE((t *)s.ptr, r.start, r.end)
+// Variant for when the start and end indices are statically known (i.e., the
+// range argument `r` is a literal).
+#define Eurydice_slice_subslice2(s, start, end, t, _)                          \
+  EURYDICE_SLICE((t *)s.ptr, start, end)
 #define Eurydice_slice_subslice_to(s, subslice_end_pos, t, _, _ret_t)          \
   EURYDICE_SLICE((t *)s.ptr, 0, subslice_end_pos)
 #define Eurydice_slice_subslice_from(s, subslice_start_pos, t, _, _ret_t)      \

--- a/lib/Cleanup1.ml
+++ b/lib/Cleanup1.ml
@@ -182,6 +182,8 @@ let remove_assignments =
       | EWhile (e, e') ->
           assert (b.node.meta = Some MetaSequence);
           close_now_over not_yet_closed
+            (* We must be here variables that are declared in the condition, and variables that
+               appear both in the loop body and its continuation. *)
             (count e ++ AtomSet.inter (count e') (count e2))
             (fun not_yet_closed ->
               ELet

--- a/lib/Cleanup3.ml
+++ b/lib/Cleanup3.ml
@@ -114,4 +114,21 @@ let add_extra_type_to_slice_index =
       | EQualified ([ "Eurydice" ], "slice_index"), [], [], [ t_elements ] ->
           ETApp (e, cgs, cgs', ts @ [ TBuf (t_elements, false) ])
       | _ -> super#visit_ETApp env e cgs cgs' ts
+
+    method! visit_EApp env e es =
+      match e.node, es with
+      | ( ETApp
+            ({ node = EQualified ([ "Eurydice" ], "slice_subslice"); _ }, [], [], [ t_elements; _ ]),
+          [ e_slice; { node = EFlat [ Some "start", e_start; Some "end", e_end
+          ]; typ = TQualified (["core"; "ops"; "range"], id) } ] )
+        when KString.starts_with id "Range" ->
+          EApp
+            ( with_type TUnit
+                (ETApp
+                   ( with_type TUnit (EQualified ([ "Eurydice" ], "slice_subslice2")),
+                     [],
+                     [],
+                     [ t_elements ] )),
+              [ e_slice; e_start; e_end ] )
+      | _ -> super#visit_EApp env e es
   end

--- a/lib/Cleanup3.ml
+++ b/lib/Cleanup3.ml
@@ -92,6 +92,19 @@ let decay_cg_externals =
         DExternal (cc, flags, n_cgs, n, name, Helpers.fold_arrow t_args t_ret, hints)
   end
 
+let bonus_cleanups =
+  object (_self)
+    inherit [_] map as super
+
+    method! visit_ELet (((), _) as env) b e1 e2 =
+      (* let x; x := e; return x *)
+      match e1.node, e2.node with
+      | ( EAny,
+          ESequence [ { node = EAssign ({ node = EBound 0; _ }, e3); _ }; { node = EBound 0; _ } ] )
+        -> (DeBruijn.subst Helpers.eunit 0 e3).node
+      | _ -> super#visit_ELet env b e1 e2
+  end
+
 let build_cg_macros =
   object (self)
     inherit [_] Krml.Ast.reduce
@@ -119,8 +132,13 @@ let add_extra_type_to_slice_index =
       match e.node, es with
       | ( ETApp
             ({ node = EQualified ([ "Eurydice" ], "slice_subslice"); _ }, [], [], [ t_elements; _ ]),
-          [ e_slice; { node = EFlat [ Some "start", e_start; Some "end", e_end
-          ]; typ = TQualified (["core"; "ops"; "range"], id) } ] )
+          [
+            e_slice;
+            {
+              node = EFlat [ (Some "start", e_start); (Some "end", e_end) ];
+              typ = TQualified ([ "core"; "ops"; "range" ], id);
+            };
+          ] )
         when KString.starts_with id "Range" ->
           EApp
             ( with_type TUnit
@@ -131,9 +149,17 @@ let add_extra_type_to_slice_index =
                      [ t_elements ] )),
               [ e_slice; e_start; e_end ] )
       | ( ETApp
-            ({ node = EQualified ([ "Eurydice" ], "array_to_subslice"); _ }, _, [], [ t_elements; _ ]),
-          [ e_slice; { node = EFlat [ Some "start", e_start; Some "end", e_end
-          ]; typ = TQualified (["core"; "ops"; "range"], id) } ] )
+            ( { node = EQualified ([ "Eurydice" ], "array_to_subslice"); _ },
+              _,
+              [],
+              [ t_elements; _ ] ),
+          [
+            e_slice;
+            {
+              node = EFlat [ (Some "start", e_start); (Some "end", e_end) ];
+              typ = TQualified ([ "core"; "ops"; "range" ], id);
+            };
+          ] )
         when KString.starts_with id "Range" ->
           EApp
             ( with_type TUnit

--- a/lib/Cleanup3.ml
+++ b/lib/Cleanup3.ml
@@ -130,5 +130,18 @@ let add_extra_type_to_slice_index =
                      [],
                      [ t_elements ] )),
               [ e_slice; e_start; e_end ] )
+      | ( ETApp
+            ({ node = EQualified ([ "Eurydice" ], "array_to_subslice"); _ }, _, [], [ t_elements; _ ]),
+          [ e_slice; { node = EFlat [ Some "start", e_start; Some "end", e_end
+          ]; typ = TQualified (["core"; "ops"; "range"], id) } ] )
+        when KString.starts_with id "Range" ->
+          EApp
+            ( with_type TUnit
+                (ETApp
+                   ( with_type TUnit (EQualified ([ "Eurydice" ], "array_to_subslice2")),
+                     [],
+                     [],
+                     [ t_elements ] )),
+              [ e_slice; e_start; e_end ] )
       | _ -> super#visit_EApp env e es
   end

--- a/test/partial_eq/stubs.c
+++ b/test/partial_eq/stubs.c
@@ -1,6 +1,6 @@
 #include "partial_eq.h"
 
-extern core_result_Result_____core_fmt_Error
+extern core_result_Result_86
 core_fmt__core__fmt__Formatter__a__7__write_str(core_fmt_Formatter *x0, Prims_string x1) {
-  return ((core_result_Result_____core_fmt_Error){ .tag = core_result_Ok, .f0 = NULL });
+  return ((core_result_Result_86){ .tag = core_result_Ok, .f0 = NULL });
 }


### PR DESCRIPTION
- array_to_slice and slice_subslice now have variants where the range indices are known at call-site
- some peephole optimization to avoid some array copies
- leverage krml's short names option and add further logic to avoid polluting toplevel function names with the name of the trait impl they come from