### PR TITLE
Split the check-charon-pin job in two

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -12,13 +12,21 @@ jobs:
       - name: Build and test
         run: nix flake check -L
 
-  check-charon-pin:
+  charon-pin-is-forward:
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # deep clone in order to get access to other commits
-      - run: nix develop '.#ci' --command ./scripts/ci-check-charon-pin.sh
+      - run: nix develop '.#ci' --command ./scripts/ci-check-charon-pin-is-forward.sh
+
+  charon-pin-is-merged:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # deep clone in order to get access to other commits
+      - run: nix develop '.#ci' --command ./scripts/ci-check-charon-pin-is-merged.sh
 
   kyber:
     needs: [check]

--- a/scripts/ci-check-charon-pin-is-forward.sh
+++ b/scripts/ci-check-charon-pin-is-forward.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
-# Checks that the charon pin:
-# - moves forward from the previous pin, to ensure we don't regress the Charon version;
-# - is merged into Charon.
+# Checks that the charon pin moves forward from the previous pin, to ensure we don't regress the Charon version.
 
 NEW_CHARON_PIN="$(cat flake.lock | jq -r .nodes.charon.locked.rev)"
 OLD_CHARON_PIN="$(git show origin/main:flake.lock | jq -r .nodes.charon.locked.rev)"
@@ -9,14 +7,8 @@ echo "This PR updates the charon pin from $OLD_CHARON_PIN to $NEW_CHARON_PIN"
 
 git clone https://github.com/AeneasVerif/charon
 cd charon
-CHARON_MAIN="$(git rev-parse HEAD)"
 
 if ! git merge-base --is-ancestor "$OLD_CHARON_PIN" "$NEW_CHARON_PIN"; then
     echo "Error: the new charon pin does not have the old one as its ancestor. The pin must only move forward."
-    exit 1
-fi
-
-if ! git merge-base --is-ancestor "$NEW_CHARON_PIN" "$CHARON_MAIN"; then
-    echo "Error: commit $NEW_CHARON_PIN is not merged into Charon."
     exit 1
 fi

--- a/scripts/ci-check-charon-pin-is-merged.sh
+++ b/scripts/ci-check-charon-pin-is-merged.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Checks that the charon pin is merged into Charon.
+
+NEW_CHARON_PIN="$(cat flake.lock | jq -r .nodes.charon.locked.rev)"
+OLD_CHARON_PIN="$(git show origin/main:flake.lock | jq -r .nodes.charon.locked.rev)"
+echo "This PR updates the charon pin from $OLD_CHARON_PIN to $NEW_CHARON_PIN"
+
+git clone https://github.com/AeneasVerif/charon
+cd charon
+CHARON_MAIN="$(git rev-parse HEAD)"
+
+if ! git merge-base --is-ancestor "$NEW_CHARON_PIN" "$CHARON_MAIN"; then
+    echo "Error: commit $NEW_CHARON_PIN is not merged into Charon."
+    exit 1
+fi


### PR DESCRIPTION
This is so we can distinguish the non-forward case (bad) from the not-yet-merged case (expected when doing synchronized changes).