### PR TITLE
Use circus-green flake in CI

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -34,22 +34,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          # Flake overrides aren't recursive: if I want to use eurydice with
-          # all its dependencies, I must override each of them.
+          # Flake overrides aren't recursive: if we want to use eurydice with
+          # any newly pinned dependencies, we must override all of them.
+          EURYDICE_REV="${{ github.sha }}"
           CHARON_REV="$(nix develop '.#ci' --command jq -r .nodes.charon.locked.rev flake.lock)"
           KRML_REV="$(nix develop '.#ci' --command jq -r .nodes.karamel.locked.rev flake.lock)"
           FSTAR_REV="$(nix develop '.#ci' --command jq -r .nodes.fstar.locked.rev flake.lock)"
-          git clone https://github.com/cryspen/libcrux
-          cd libcrux
-          nix develop --command cargo generate-lockfile
-          nix build --refresh -L '.#ml-kem' \
-              --override-input eurydice github:aeneasverif/eurydice/${{ github.sha }} \
-              --override-input charon github:aeneasverif/charon/$CHARON_REV \
-              --override-input karamel github:FStarLang/karamel/$KRML_REV \
-              --override-input fstar github:FStarLang/fstar/$FSTAR_REV \
-              --override-input eurydice/charon github:aeneasverif/charon/$CHARON_REV \
-              --override-input eurydice/karamel github:FStarLang/karamel/$KRML_REV \
-              --override-input eurydice/fstar github:FStarLang/fstar/$FSTAR_REV \
-              --update-input charon/rust-overlay \
-              --update-input hax \
-              --update-input crane
+          git clone https://github.com/Inria-Prosecco/circus-green
+          cd circus-green
+          nix flake lock --override-input charon github:aeneasverif/charon/$CHARON_REV
+          nix flake lock --override-input eurydice github:aeneasverif/eurydice/$EURYDICE_REV
+          nix flake lock --override-input eurydice/karamel github:FStarLang/karamel/$KRML_REV
+          nix flake lock --override-input eurydice/fstar github:FStarLang/fstar/$FSTAR_REV
+          ./check.sh ml-kem-small

--- a/flake.lock
+++ b/flake.lock
@@ -77,24 +77,6 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_3": {
-      "inputs": {
-        "systems": "systems_3"
-      },
-      "locked": {
         "lastModified": 1692799911,
         "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
         "owner": "numtide",
@@ -109,7 +91,7 @@
     },
     "fstar": {
       "inputs": {
-        "flake-utils": "flake-utils_3",
+        "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs"
       },
       "locked": {
@@ -172,7 +154,10 @@
     "root": {
       "inputs": {
         "charon": "charon",
-        "flake-utils": "flake-utils_2",
+        "flake-utils": [
+          "karamel",
+          "flake-utils"
+        ],
         "fstar": [
           "karamel",
           "fstar"
@@ -221,21 +206,6 @@
       }
     },
     "systems_2": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_3": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,8 @@
 {
   inputs = {
-    flake-utils.url = "github:numtide/flake-utils";
     karamel.url = "github:FStarLang/karamel";
     fstar.follows = "karamel/fstar";
-
+    flake-utils.follows = "karamel/flake-utils";
     nixpkgs.follows = "karamel/nixpkgs";
 
     charon.url = "github:AeneasVerif/charon";


### PR DESCRIPTION
That flake keeps the last known-good version of kyber. This makes sure CI still passes if the kyber build broke for an unrelated reason.