### PR TITLE
CI tweaks

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -6,6 +6,11 @@ on:
       - main
   pull_request:
 
+# Cancel previous versions of this job that are still running.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: self-hosted

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -2,6 +2,8 @@ name: Build Eurydice and run tests
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
This PR:
- makes it so we don't run CI on push to non-main branches, which solves the issue of every job being run twice on PRs made from this repo;
- makes it so when you push to a PR, still-running jobs for this PRs get canceled (which GitHub doesn't do by default).