### PR TITLE
Update charon

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -11,11 +11,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1733497099,
-        "narHash": "sha256-5x2+IwVbhE0Jm8pCR/qgjeLlf7BzoqNTySBcoqiJIbs=",
+        "lastModified": 1733735940,
+        "narHash": "sha256-4eZTI72w5iTqV31z99ErYi2/q1cEfc/ZZCuI5ZoEIaI=",
         "owner": "aeneasverif",
         "repo": "charon",
-        "rev": "2765f0b751a9a0aedd1e3bcbe3d38e7548fb11ff",
+        "rev": "b487babe3ae3021b484373ce59196896e3b43448",
         "type": "github"
       },
       "original": {
@@ -173,11 +173,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733452419,
-        "narHash": "sha256-eh2i2GtqdWVOP7yjiWtB8FMUWktCZ4vjo81n6g5mSiE=",
+        "lastModified": 1733884434,
+        "narHash": "sha256-8GXR9kC07dyOIshAyfZhG11xfvBRSZzYghnZ2weOKJU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "020701e6057992329a7cfafc6e3c5d5658bbcf79",
+        "rev": "d0483df44ddf0fd1985f564abccbe568e020ddf2",
         "type": "github"
       },
       "original": {

--- a/lib/AstOfLlbc.ml
+++ b/lib/AstOfLlbc.ml
@@ -8,12 +8,18 @@ module C = struct
   include Charon.Values
   include Charon.GAstUtils
 
+  (* Fails if the variable is bound *)
+  let expect_free_var (var : ('b, 'f) de_bruijn_var) : 'f =
+    match var with
+    | Free id -> id
+    | Bound _ -> failwith "Found unexpected bound variable"
+
   let tsubst cgs ts ty =
     begin
       object
         inherit [_] map_ty
-        method! visit_TVar _ v = TypeVarId.nth ts v
-        method! visit_CgVar _ v = ConstGenericVarId.nth cgs v
+        method! visit_TVar _ v = TypeVarId.nth ts (expect_free_var v)
+        method! visit_CgVar _ v = ConstGenericVarId.nth cgs (expect_free_var v)
         method visit_'r _ x = x
       end
     end
@@ -298,7 +304,7 @@ let assert_cg_scalar = function
 
 let cg_of_const_generic env cg =
   match cg with
-  | C.CgVar id -> K.CgVar (fst (lookup_cg_in_types env id))
+  | C.CgVar var -> K.CgVar (fst (lookup_cg_in_types env (C.expect_free_var var)))
   | C.CgValue (VScalar sv) -> CgConst (constant_of_scalar_value sv)
   | _ ->
       failwith
@@ -313,7 +319,7 @@ let typ_of_literal_ty (_env : env) (ty : Charon.Types.literal_type) : K.typ =
 
 let rec typ_of_ty (env : env) (ty : Charon.Types.ty) : K.typ =
   match ty with
-  | TVar id -> K.TBound (lookup_typ env id)
+  | TVar var -> K.TBound (lookup_typ env (C.expect_free_var var))
   | TLiteral t -> typ_of_literal_ty env t
   | TNever -> failwith "Impossible: Never"
   | TDynTrait _ -> failwith "TODO: dyn Trait"
@@ -376,8 +382,8 @@ let rec typ_of_ty (env : env) (ty : Charon.Types.ty) : K.typ =
 and maybe_cg_array env t cg =
   match cg with
   | CgValue _ -> K.TArray (typ_of_ty env t, constant_of_scalar_value (assert_cg_scalar cg))
-  | CgVar id ->
-      let id, cg_t = lookup_cg_in_types env id in
+  | CgVar var ->
+      let id, cg_t = lookup_cg_in_types env (C.expect_free_var var) in
       assert (cg_t = K.TInt SizeT);
       K.TCgArray (typ_of_ty env t, id)
   | _ -> failwith "TODO: CgGlobal"
@@ -516,7 +522,7 @@ let expression_of_literal (_env : env) (l : C.literal) : K.expr =
 let expression_of_const_generic env cg =
   match cg with
   | C.CgGlobal _ -> failwith "TODO: CgGLobal"
-  | C.CgVar id -> expression_of_cg_var_id env id
+  | C.CgVar var -> expression_of_cg_var_id env (C.expect_free_var var)
   | C.CgValue l -> expression_of_literal env l
 
 let ensure_named i name =
@@ -768,7 +774,7 @@ let rec build_trait_clause_mapping env (trait_clauses : C.trait_clause list) :
                 n_cgs = List.length trait_decl.generics.const_generics;
               }
             in
-            ( (C.Clause clause_id, item_name),
+            ( (C.Clause (Free clause_id), item_name),
               (decl_generics, ts, trait_decl.C.item_meta.name, decl.C.signature) ))
           (trait_decl.C.required_methods @ trait_decl.C.provided_methods)
         @ List.flatten
@@ -781,11 +787,11 @@ let rec build_trait_clause_mapping env (trait_clauses : C.trait_clause list) :
                      (* This is the parent clause `clause_id'` of `clause_id` -- see comments in charon/types.rs  *)
                      let clause_id' =
                        match clause_id' with
-                       | Clause clause_id' -> clause_id'
+                       | Clause (Free clause_id') -> clause_id'
                        | _ -> fail "not a clause??"
                      in
                      let id : C.trait_instance_id =
-                       ParentClause (Clause clause_id, trait_decl_id, clause_id')
+                       ParentClause (Clause (Free clause_id), trait_decl_id, clause_id')
                      in
                      (id, m), v)
                    m)
@@ -1195,7 +1201,7 @@ let expression_of_operand (env : env) (op : C.operand) : K.expr =
       end
   | Move p -> expression_of_place env p
   | Constant { value = CLiteral l; _ } -> expression_of_literal env l
-  | Constant { value = CVar id; _ } -> expression_of_cg_var_id env id
+  | Constant { value = CVar var; _ } -> expression_of_cg_var_id env (C.expect_free_var var)
   | Constant { value = CFnPtr fn_ptr; _ } ->
       let e, _, _ = expression_of_fn_ptr env fn_ptr in
       e


### PR DESCRIPTION
Companion PR to https://github.com/AeneasVerif/charon/pull/491.

Now all the type-level variables (types, const generics, and trait clauses) can be bound or free. All existing uses become `Free`, some future uses (for trait methods in particular) will introduce `Bound` variables.