### PR TITLE
Use the correct version of ocamlformat in nix shell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -151,6 +151,22 @@
         "type": "indirect"
       }
     },
+    "recent_nixpkgs": {
+      "locked": {
+        "lastModified": 1735563628,
+        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "charon": "charon",
@@ -162,7 +178,8 @@
         "nixpkgs": [
           "karamel",
           "nixpkgs"
-        ]
+        ],
+        "recent_nixpkgs": "recent_nixpkgs"
       }
     },
     "rust-overlay": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,11 @@
   inputs = {
     karamel.url = "github:FStarLang/karamel";
     flake-utils.follows = "karamel/flake-utils";
+    # Need to use same-ish nixpkgs version as karamel to gt a compatible ocaml
+    # toolchain
     nixpkgs.follows = "karamel/nixpkgs";
+    # Need a recent nixpkgs to get ocamlformat 0.26.2
+    recent_nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
 
     charon.url = "github:AeneasVerif/charon";
     charon.inputs.nixpkgs.follows = "nixpkgs";
@@ -11,11 +15,13 @@
     { self
     , flake-utils
     , nixpkgs
+    , recent_nixpkgs
     , ...
     } @ inputs:
     flake-utils.lib.eachDefaultSystem (system:
     let
       pkgs = import nixpkgs { inherit system; };
+      recent_pkgs = import recent_nixpkgs { inherit system; };
 
       karamel = inputs.karamel.packages.${system}.default;
       fstar = inputs.karamel.inputs.fstar.packages.${system}.default;
@@ -87,7 +93,7 @@
         packages = [
           pkgs.clang-tools # For clang-format
           pkgs.ocamlPackages.ocaml
-          pkgs.ocamlPackages.ocamlformat
+          recent_pkgs.ocamlPackages.ocamlformat_0_26_2
           pkgs.ocamlPackages.menhir
           # ocaml-lsp's version must match the ocaml version used. Pinning
           # this here to save me a headache.


### PR DESCRIPTION
I wondered in https://github.com/AeneasVerif/eurydice/pull/121 whether the formatting change was due to an `ocamlformat` version mismatch, and it appears not. Either way it makes my life easier to use the expected version, which this PR does.