### PR TITLE
Update charon

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -11,11 +11,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1736369122,
-        "narHash": "sha256-LKddoHMQKNJBzeY4c3zQUy+bNCgjlBdKfs7TghpQodI=",
-        "owner": "AeneasVerif",
+        "lastModified": 1736774658,
+        "narHash": "sha256-kkzeJwzkSJ9S5TaJ1MrIt9uUPugHBrtnIVcmUFi0FEE=",
+        "owner": "aeneasverif",
         "repo": "charon",
-        "rev": "df3b7fd4c1277827c92b4a2cb84347f1f54d92a6",
+        "rev": "fd47c649cb7e691e7d1c70e8b896637cb847214c",
         "type": "github"
       },
       "original": {

--- a/out/test-const_generics/const_generics.c
+++ b/out/test-const_generics/const_generics.c
@@ -179,14 +179,23 @@ with const generics
 */
 bool const_generics_g_70(uint32_t x, size_t y)
 {
+  bool uu____0;
   if (const_generics_f_70(x, y))
   {
     if (x == 4U)
     {
-      return y == (size_t)3U;
+      uu____0 = y == (size_t)3U;
+    }
+    else
+    {
+      uu____0 = false;
     }
   }
-  return false;
+  else
+  {
+    uu____0 = false;
+  }
+  return uu____0;
 }
 
 typedef struct _bool__x2_s

--- a/scripts/update-charon-pin.sh
+++ b/scripts/update-charon-pin.sh
@@ -9,4 +9,3 @@ CHARON_BRANCH="$(git -C "$CHARON_DIR" rev-parse --abbrev-ref HEAD)"
 CHARON_COMMIT="$(git -C "$CHARON_DIR" rev-parse HEAD)"
 echo 'Taking the commit from your local charon directory. The charon branch is `'"$CHARON_BRANCH"'`'
 nix flake lock --extra-experimental-features nix-command --extra-experimental-features flakes --override-input charon "github:aeneasverif/charon/$CHARON_COMMIT"
-nix flake lock --extra-experimental-features nix-command --extra-experimental-features flakes --update-input charon/rust-overlay


### PR DESCRIPTION
Companion PR to https://github.com/AeneasVerif/charon/pull/520.

There was a race condition between https://github.com/AeneasVerif/charon/pull/520 and https://github.com/AeneasVerif/eurydice/pull/131 which were merged close together with green CIs despite the fact that they break one another. This fixes that.