### PR TITLE
small fix for compilation with ocaml 5.1.1

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -32,7 +32,7 @@ Supported options:|}
   let spec = Arg.align spec in
   let files = ref [] in
   let fatal_error =
-    Printf.kprintf (fun s ->
+    Printf.ksprintf (fun s ->
         print_endline s;
         exit 255)
   in


### PR DESCRIPTION
This fix allows eurydice to be compiled with ocaml 5.1.1
Without it, the build errors out with:
```
dune build && ln -sf _build/default/bin/main.exe eurydice
File "bin/main.ml", line 35, characters 4-18:
35 |     Printf.kprintf (fun s ->
         ^^^^^^^^^^^^^^
Error (alert deprecated): Stdlib.Printf.kprintf
Use Printf.ksprintf instead.
```