### PR TITLE
Make `charon` available in the flake output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -100,9 +100,12 @@
         eurydice;
     in
     rec {
-      packages.default = pkgs.callPackage package {
-        inherit charon-ml krml;
-        version = self.rev or "dirty";
+      packages = {
+        default = pkgs.callPackage package {
+          inherit charon-ml krml;
+          version = self.rev or "dirty";
+        };
+        inherit charon;
       };
       checks.default = packages.default.tests;
       devShells.ci = pkgs.mkShell { packages = [ pkgs.jq ]; };


### PR DESCRIPTION
This makes life easier for users of eurydice: the provided charon is guaranteed to be compatible with the provided eurydice.