### PR TITLE
support for `FnOpMove`

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -342,6 +342,7 @@ Supported options:|}
             ds ))
       files
   in
+  let files = Eurydice.Cleanup3.unpack_apply_funcs files in
 
   Eurydice.Logging.log "Phase3.3" "%a" pfiles files;
   let files =

--- a/lib/Cleanup3.ml
+++ b/lib/Cleanup3.ml
@@ -179,7 +179,7 @@ let unpack_apply_funcs (files : files) =
     inherit [_] map as super
 
     method! visit_EQualified ((found,_) as env) name =
-      if AstOfLlbc.is_apply_func_name name then begin
+      if AstOfLlbc.FnOpMoveHelper.is_apply_func_name name then begin
         Logging.log "unpack" 
           "[unpack, found] Found apply function: %s\n" @@ snd name;
         found := true
@@ -214,7 +214,7 @@ let unpack_apply_funcs (files : files) =
     let is_apply_func (decl : decl) =
       match decl with
       | DExternal (_, _, _, _, name, _, _)
-          when AstOfLlbc.is_apply_func_name name -> false
+          when AstOfLlbc.FnOpMoveHelper.is_apply_func_name name -> false
       | _otw -> true
     in
     List.map (fun (name,decls) -> (name,List.filter is_apply_func decls)) files

--- a/test/fn_higher_order.rs
+++ b/test/fn_higher_order.rs
@@ -1,0 +1,28 @@
+
+fn sum_lst<const N : usize>(lst : &[usize;N]) -> usize {
+  let mut sum = 0;
+  for i in 0 .. N { sum = sum + lst[i]; }
+  sum + N
+}
+
+fn more_sum_lst(l : &[i32; 3]) -> i32 {
+  let mut sum = 0;
+  for i in 0..3 { sum = sum + l[i]; }
+  sum
+}
+
+fn id<R>(r : R) -> R { r }
+
+fn compose_cg_apply<X : Copy,Y,const N : usize,Z>(
+  f : fn(&[X;N]) -> Y, 
+  g : fn(Y) -> Z, 
+  arg : &[X;N]) -> Z {
+  g(f(arg))
+}
+
+fn use_compose_cg() {
+  let x = compose_cg_apply(sum_lst, id, &[1,2,3,4,5]);
+  let y = compose_cg_apply(more_sum_lst, id, &[10,11,12]);
+  println!("x = {}", x);
+  println!("y = {}", y);
+}


### PR DESCRIPTION
The major hurdle of supporting this lies in the tunability of Low* to handle higher-order types. So I instead introduce the "apply functions" `::$apply$k` where `k` is a unique identifier for each such higher-order application. So, `f(...)` is turned to `::$apply$k(f, ...)`. Then, after all checks and Cleanup, unpack the `::$apply$k$` functions and recover the original application, so to work around the hurdle.

The major technical hurdle lies in handling the quite complex representation of (const) generics. While this might not be that useful if Charon fully supports monomorphization, I believe it still contributes to the overall robustness.

Newly handled examples below:

```Rust
fn sum_lst<const N : usize>(lst : &[usize;N]) -> usize {
    let mut sum = 0;
    for i in 0 .. N { sum = sum + lst[i]; }
    sum + N
}

fn more_sum_lst(l : &[i32; 3]) -> i32 {
    let mut sum = 0;
    for i in 0..3 { sum = sum + l[i]; }
    sum
}

fn id<R>(r : R) -> R { r }

fn compose_cg_apply<X : Copy,Y,const N : usize,Z>(
    f : fn(&[X;N]) -> Y, 
    g : fn(Y) -> Z, 
    arg : &[X;N]) -> Z {
    g(f(arg))
}

fn use_compose_cg() {
    let x = compose_cg_apply(sum_lst, id, &[1,2,3,4,5]);
    let y = compose_cg_apply(more_sum_lst, id, &[10,11,12]);
    println!("x = {}", x);
    println!("y = {}", y);
}
```