### PR TITLE
Use charon's cli preset for eurydice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ clean-and-test:
 
 .PRECIOUS: %.llbc
 %.llbc: %.rs
-	$(CHARON) rustc --remove-associated-types '*' --dest-file "$@" -- $<
+	$(CHARON) rustc --preset=eurydice --dest-file "$@" -- $<
 
 out/test-%/main.c: test/main.c
 	mkdir -p out/test-$*

--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1745919987,
-        "narHash": "sha256-EMY9T6VFYw0/u13boDLYAIPmZVaK8MtwN2eW7Yl9TYA=",
+        "lastModified": 1746455098,
+        "narHash": "sha256-bo9jtIZuoYgQYNvKdp8Bbc0IwdUuA9JJ50KzVMJTUGU=",
         "owner": "aeneasverif",
         "repo": "charon",
-        "rev": "a13f834b16bd1a673687d6867e2c512df02c43af",
+        "rev": "e7773bd3205c83c4b4ae7181fe32177f477cf633",
         "type": "github"
       },
       "original": {

--- a/lib/AstOfLlbc.ml
+++ b/lib/AstOfLlbc.ml
@@ -2067,8 +2067,7 @@ let file_of_crate (crate : Charon.LlbcAst.crate) : Krml.Ast.file =
     crate
   in
   if options.remove_associated_types <> [ "*" ] then begin
-    Printf.eprintf
-      "ERROR: Eurydice expects Charon to be invoked with exactly --remove-associated-types '*'\n";
+    Printf.eprintf "ERROR: Eurydice expects Charon to be invoked with `--preset=eurydice`\n";
     exit 255
   end;
   seen := 0;


### PR DESCRIPTION
Companion PR to https://github.com/AeneasVerif/charon/pull/673.

This will make it easy for charon to tweak its default options. Eventually we might remove presets or replace them with more semantically-meaningful ones than "aeneas"/"eurydice".