### PR TITLE
fn debug: fixing no parameter case

### DIFF
--- a/lib/AstOfLlbc.ml
+++ b/lib/AstOfLlbc.ml
@@ -456,7 +456,16 @@ let rec pre_typ_of_ty (env : env) (ty : Charon.Types.ty) : K.typ =
   | TTraitType _ -> failwith ("TODO: TraitTypes " ^ Charon.PrintTypes.ty_to_string env.format_env ty)
   | TArrow binder | TClosure (_, _, _, binder) ->
       let ts, t = binder.binder_value in
-      Krml.Helpers.fold_arrow (List.map (typ_of_ty env) ts) (typ_of_ty env t)
+      let typs = List.map (typ_of_ty env) ts in
+      let typs =
+        match typs with
+        | [] -> [ K.TUnit ]
+        | typs -> typs
+      in begin
+      match typ_of_ty env t with
+      | TArrow _ -> failwith "Function pointer `fn` currying is not supported, consider using `&'static dyn Fn` instead."
+      | typ -> Krml.Helpers.fold_arrow typs typ
+      end
   | TError _ -> failwith "Found type error in charon's output"
 
 and typ_of_ty (env : env) (ty : Charon.Types.ty) : K.typ =

--- a/out/test-fn_higher_order/fn_higher_order.c
+++ b/out/test-fn_higher_order/fn_higher_order.c
@@ -7,6 +7,11 @@
 
 #include "fn_higher_order.h"
 
+int32_t fn_higher_order_empty_ptr(int32_t (*f)(void))
+{
+  return f();
+}
+
 int32_t fn_higher_order_more_sum_lst(int32_t *l)
 {
   int32_t sum = (int32_t)0;
@@ -135,5 +140,10 @@ void fn_higher_order_use_compose_cg(void)
 void fn_higher_order_main(void)
 {
   fn_higher_order_use_compose_cg();
+}
+
+void fn_higher_order_unit_empty_ptr(void (*f)(void))
+{
+  f();
 }
 

--- a/out/test-fn_higher_order/fn_higher_order.h
+++ b/out/test-fn_higher_order/fn_higher_order.h
@@ -90,6 +90,8 @@ core_iter_range___core__iter__range__Step_for_usize__43__steps_between(size_t *x
 
 typedef uint8_t core_panicking_AssertKind;
 
+int32_t fn_higher_order_empty_ptr(int32_t (*f)(void));
+
 int32_t fn_higher_order_more_sum_lst(int32_t *l);
 
 /**
@@ -142,6 +144,8 @@ int32_t fn_higher_order_id_a8(int32_t r);
 void fn_higher_order_use_compose_cg(void);
 
 void fn_higher_order_main(void);
+
+void fn_higher_order_unit_empty_ptr(void (*f)(void));
 
 #if defined(__cplusplus)
 }

--- a/test/fn_higher_order.rs
+++ b/test/fn_higher_order.rs
@@ -11,6 +11,14 @@ fn more_sum_lst(l : &[i32; 3]) -> i32 {
   sum
 }
 
+fn empty_ptr(f : fn() -> i32) -> i32 {
+  f()
+}
+
+fn unit_empty_ptr(f : fn()) {
+  f()
+}
+
 fn id<R>(r : R) -> R { r }
 
 fn compose_cg_apply<X : Copy,Y,const N : usize,Z>(


### PR DESCRIPTION
Debugging the `fn` support. The original implementation will fail if `fn` has no parameter.

E.g.,

```Rust
fn empty_ptr(f : fn() -> i32) -> i32 {
  f()
}
```

Now this case is supported -- the only change is the support for type.