### PR TITLE
Add core_num__u64_9__rotate_left

### DIFF
--- a/include/eurydice_glue.h
+++ b/include/eurydice_glue.h
@@ -311,8 +311,7 @@ static inline uint16_t core_num__u16_7__wrapping_add(uint16_t x, uint16_t y) {
 static inline uint8_t core_num__u8_6__wrapping_sub(uint8_t x, uint8_t y) {
   return x - y;
 }
-static inline uint64_t core_num__u64_9__rotate_left(uint64_t x0,
-                                                             uint32_t x1) {
+static inline uint64_t core_num__u64_9__rotate_left(uint64_t x0, uint32_t x1) {
   return (x0 << x1 | x0 >> (64 - x1));
 }
 

--- a/include/eurydice_glue.h
+++ b/include/eurydice_glue.h
@@ -311,6 +311,10 @@ static inline uint16_t core_num__u16_7__wrapping_add(uint16_t x, uint16_t y) {
 static inline uint8_t core_num__u8_6__wrapping_sub(uint8_t x, uint8_t y) {
   return x - y;
 }
+static KRML_MUSTINLINE uint64_t core_num__u64_9__rotate_left(uint64_t x0,
+                                                             uint32_t x1) {
+  return (x0 << x1 | x0 >> (64 - x1));
+}
 
 static inline void core_ops_arith__i32_319__add_assign(int32_t *x0,
                                                        int32_t *x1) {

--- a/include/eurydice_glue.h
+++ b/include/eurydice_glue.h
@@ -311,7 +311,7 @@ static inline uint16_t core_num__u16_7__wrapping_add(uint16_t x, uint16_t y) {
 static inline uint8_t core_num__u8_6__wrapping_sub(uint8_t x, uint8_t y) {
   return x - y;
 }
-static KRML_MUSTINLINE uint64_t core_num__u64_9__rotate_left(uint64_t x0,
+static inline uint64_t core_num__u64_9__rotate_left(uint64_t x0,
                                                              uint32_t x1) {
   return (x0 << x1 | x0 >> (64 - x1));
 }


### PR DESCRIPTION
Add `core_num__u64_9__rotate_left` to the glue.

cc https://github.com/cryspen/libcrux/issues/992