### PR TITLE
Add missing subtitutions for parent clause mapping

### DIFF
--- a/lib/AstOfLlbc.ml
+++ b/lib/AstOfLlbc.ml
@@ -849,6 +849,7 @@ let blocklisted_trait_decls =
   [
     (* Handled primitively. *)
     "core::cmp::PartialEq";
+    "core::ops::function::FnMut";
     (* These don't have methods *)
     "core::marker::Sized";
     "core::marker::Send";


### PR DESCRIPTION
There was a key missing substitution in the building of the parent clause mapping. This means that previously Eurydice only supported `trait Foo<T1, ..., Tn>: Bar<T1, ..., Tn>` -- now the general case should work.

CC @franziskuskiefer because I vaguely remember you mentioning something along those lines