### PR TITLE
Fix subslice2

### DIFF
--- a/include/eurydice_glue.h
+++ b/include/eurydice_glue.h
@@ -114,7 +114,7 @@ typedef struct {
 // Variant for when the start and end indices are statically known (i.e., the
 // range argument `r` is a literal).
 #define Eurydice_slice_subslice2(s, start, end, t)                             \
-  EURYDICE_SLICE((t *)s.ptr, start, end)
+  EURYDICE_SLICE((t *)s.ptr, (start), (end))
 
 #define Eurydice_slice_subslice_to(s, subslice_end_pos, t, _0, _1)             \
   EURYDICE_SLICE((t *)s.ptr, 0, subslice_end_pos)
@@ -130,7 +130,7 @@ typedef struct {
 
 // Same as above, variant for when start and end are statically known
 #define Eurydice_array_to_subslice2(x, start, end, t)                          \
-  EURYDICE_SLICE((t *)x, start, end)
+  EURYDICE_SLICE((t *)x, (start), (end))
 
 #define Eurydice_array_repeat(dst, len, init, t)                               \
   ERROR "should've been desugared"


### PR DESCRIPTION
If the ranges are computed in the arguments itself in Rust, not having brackets for `start` and `end` causes the length computation in `EURYDICE_SLICE` to break.

There may be more places that need fixing.