### PR TITLE
Ignore impl disambiguators in names

### DIFF
--- a/include/eurydice_glue.h
+++ b/include/eurydice_glue.h
@@ -146,10 +146,10 @@ typedef struct {
 #define Eurydice_slice_copy(dst, src, t)                                       \
   memcpy(dst.ptr, src.ptr, dst.len * sizeof(t))
 
-#define core_array___Array_T__N__23__as_slice(len_, ptr_, t, _ret_t)           \
+#define core_array___Array_T__N___as_slice(len_, ptr_, t, _ret_t)           \
   KRML_CLITERAL(Eurydice_slice) { ptr_, len_ }
 
-#define core_array___core__clone__Clone_for__Array_T__N___20__clone(           \
+#define core_array__core__clone__Clone_for__Array_T__N___clone(           \
     len, src, dst, elem_type, _ret_t)                                          \
   (memcpy(dst, src, len * sizeof(elem_type)))
 #define TryFromSliceError uint8_t
@@ -157,10 +157,10 @@ typedef struct {
 
 #define Eurydice_array_eq(sz, a1, a2, t, _)                                    \
   (memcmp(a1, a2, sz * sizeof(t)) == 0)
-#define core_array_equality___core__cmp__PartialEq__Array_U__N___for__Array_T__N____eq( \
+#define core_array_equality__core__cmp__PartialEq__Array_U__N___for__Array_T__N___eq( \
     sz, a1, a2, t, _, _ret_t)                                                           \
   Eurydice_array_eq(sz, a1, a2, t, _)
-#define core_array_equality___core__cmp__PartialEq__0___Slice_U____for__Array_T__N___3__eq( \
+#define core_array_equality__core__cmp__PartialEq__0___Slice_U____for__Array_T__N___eq( \
     sz, a1, a2, t, _, _ret_t)                                                               \
   Eurydice_array_eq(sz, a1, ((a2)->ptr), t, _)
 
@@ -238,49 +238,49 @@ typedef char Eurydice_derefed_slice[];
 extern "C" {
 #endif
 
-static inline void core_num__u32_8__to_be_bytes(uint32_t src, uint8_t dst[4]) {
+static inline void core_num__u32__to_be_bytes(uint32_t src, uint8_t dst[4]) {
   // TODO: why not store32_be?
   uint32_t x = htobe32(src);
   memcpy(dst, &x, 4);
 }
 
-static inline void core_num__u32_8__to_le_bytes(uint32_t src, uint8_t dst[4]) {
+static inline void core_num__u32__to_le_bytes(uint32_t src, uint8_t dst[4]) {
   store32_le(dst, src);
 }
 
-static inline uint32_t core_num__u32_8__from_le_bytes(uint8_t buf[4]) {
+static inline uint32_t core_num__u32__from_le_bytes(uint8_t buf[4]) {
   return load32_le(buf);
 }
 
-static inline void core_num__u64_9__to_le_bytes(uint64_t v, uint8_t buf[8]) {
+static inline void core_num__u64__to_le_bytes(uint64_t v, uint8_t buf[8]) {
   store64_le(buf, v);
 }
 
-static inline uint64_t core_num__u64_9__from_le_bytes(uint8_t buf[8]) {
+static inline uint64_t core_num__u64__from_le_bytes(uint8_t buf[8]) {
   return load64_le(buf);
 }
 
 static inline int64_t
-core_convert_num___core__convert__From_i32__for_i64__59__from(int32_t x) {
+core_convert_num__core__convert__From_i32__for_i64__from(int32_t x) {
   return x;
 }
 
 static inline uint64_t
-core_convert_num___core__convert__From_u8__for_u64__66__from(uint8_t x) {
+core_convert_num__core__convert__From_u8__for_u64__from(uint8_t x) {
   return x;
 }
 
 static inline uint64_t
-core_convert_num___core__convert__From_u16__for_u64__70__from(uint16_t x) {
+core_convert_num__core__convert__From_u16__for_u64__from(uint16_t x) {
   return x;
 }
 
 static inline size_t
-core_convert_num___core__convert__From_u16__for_usize__96__from(uint16_t x) {
+core_convert_num__core__convert__From_u16__for_usize__from(uint16_t x) {
   return x;
 }
 
-static inline uint32_t core_num__u8_6__count_ones(uint8_t x0) {
+static inline uint32_t core_num__u8__count_ones(uint8_t x0) {
 #ifdef _MSC_VER
   return __popcnt(x0);
 #else
@@ -288,7 +288,7 @@ static inline uint32_t core_num__u8_6__count_ones(uint8_t x0) {
 #endif
 }
 
-static inline uint32_t core_num__i32_2__count_ones(int32_t x0) {
+static inline uint32_t core_num__i32__count_ones(int32_t x0) {
 #ifdef _MSC_VER
   return __popcnt(x0);
 #else
@@ -297,7 +297,7 @@ static inline uint32_t core_num__i32_2__count_ones(int32_t x0) {
 }
 
 static inline size_t
-core_cmp_impls___core__cmp__Ord_for_usize__59__min(size_t a, size_t b) {
+core_cmp_impls__core__cmp__Ord_for_usize__min(size_t a, size_t b) {
   if (a <= b)
     return a;
   else
@@ -305,18 +305,18 @@ core_cmp_impls___core__cmp__Ord_for_usize__59__min(size_t a, size_t b) {
 }
 
 // unsigned overflow wraparound semantics in C
-static inline uint16_t core_num__u16_7__wrapping_add(uint16_t x, uint16_t y) {
+static inline uint16_t core_num__u16__wrapping_add(uint16_t x, uint16_t y) {
   return x + y;
 }
-static inline uint8_t core_num__u8_6__wrapping_sub(uint8_t x, uint8_t y) {
+static inline uint8_t core_num__u8__wrapping_sub(uint8_t x, uint8_t y) {
   return x - y;
 }
-static inline uint64_t core_num__u64_9__rotate_left(uint64_t x0, uint32_t x1) {
+static inline uint64_t core_num__u64__rotate_left(uint64_t x0, uint32_t x1) {
   return (x0 << x1 | x0 >> (64 - x1));
 }
 
-static inline void core_ops_arith__i32_319__add_assign(int32_t *x0,
-                                                       int32_t *x1) {
+static inline void core_ops_arith__i32__add_assign(int32_t *x0,
+                                                   int32_t *x1) {
   *x0 = *x0 + *x1;
 }
 
@@ -331,20 +331,20 @@ static inline uint32_t Eurydice_min_u32(uint32_t x, uint32_t y) {
 }
 
 static inline uint8_t
-core_ops_bit___core__ops__bit__BitAnd_u8__u8__for___a__u8___46__bitand(
+core_ops_bit__core__ops__bit__BitAnd_u8__u8__for___a__u8___bitand(
     uint8_t *x0, uint8_t x1) {
   return Eurydice_bitand_pv_u8(x0, x1);
 }
 
 static inline uint8_t
-core_ops_bit___core__ops__bit__Shr_i32__u8__for___a__u8___792__shr(uint8_t *x0,
-                                                                   int32_t x1) {
+core_ops_bit__core__ops__bit__Shr_i32__u8__for___a__u8___shr(uint8_t *x0,
+                                                             int32_t x1) {
   return Eurydice_shr_pv_u8(x0, x1);
 }
 
 #define core_num_nonzero_private_NonZeroUsizeInner size_t
 static inline core_num_nonzero_private_NonZeroUsizeInner
-core_num_nonzero_private___core__clone__Clone_for_core__num__nonzero__private__NonZeroUsizeInner__26__clone(
+core_num_nonzero_private___core__clone__Clone_for_core__num__nonzero__private__NonZeroUsizeInner___clone(
     core_num_nonzero_private_NonZeroUsizeInner *x0) {
   return *x0;
 }
@@ -362,12 +362,12 @@ core_num_nonzero_private___core__clone__Clone_for_core__num__nonzero__private__N
        : (KRML_CLITERAL(ret_t){EURYDICE_CFIELD(.tag =) 1,                      \
                                EURYDICE_CFIELD(.f0 =)(iter_ptr)->start++}))
 
-#define core_iter_range___core__iter__traits__iterator__Iterator_A__for_core__ops__range__Range_A__TraitClause_0___6__next \
+#define core_iter_range__core__iter__traits__iterator__Iterator_A__for_core__ops__range__Range_A__TraitClause_0___next \
   Eurydice_range_iter_next
 
 // See note in karamel/lib/Inlining.ml if you change this
 #define Eurydice_into_iter(x, t, _ret_t, _) (x)
-#define core_iter_traits_collect___core__iter__traits__collect__IntoIterator_Clause1_Item__I__for_I__1__into_iter \
+#define core_iter_traits_collect__core__iter__traits__collect__IntoIterator_Clause1_Item__I__for_I__into_iter \
   Eurydice_into_iter
 
 typedef struct {
@@ -404,10 +404,10 @@ static inline Eurydice_slice chunk_next(Eurydice_chunks *chunks,
   (((iter)->slice.len == 0) ? ((ret_t){.tag = core_option_None})               \
                             : ((ret_t){.tag = core_option_Some,                \
                                        .f0 = chunk_next(iter, sizeof(t))}))
-#define core_slice_iter___core__iter__traits__iterator__Iterator_for_core__slice__iter__Chunks__a__T___70__next \
+#define core_slice_iter__core__iter__traits__iterator__Iterator_for_core__slice__iter__Chunks__a__T___next \
   Eurydice_chunks_next
 // This name changed on 20240627
-#define core_slice_iter___core__iter__traits__iterator__Iterator_for_core__slice__iter__Chunks__a__T___71__next \
+#define core_slice_iter__core__iter__traits__iterator__Iterator_for_core__slice__iter__Chunks__a__T___next \
   Eurydice_chunks_next
 #define core_slice_iter__core__slice__iter__ChunksExact__a__T__89__next(       \
     iter, t, _ret_t)                                                           \
@@ -421,7 +421,7 @@ typedef struct {
 #define core_slice___Slice_T___iter(x, t, _ret_t)                              \
   ((Eurydice_slice_iterator){.s = x, .index = 0})
 #define core_slice_iter_Iter Eurydice_slice_iterator
-#define core_slice_iter__core__slice__iter__Iter__a__T__181__next(iter, t,     \
+#define core_slice_iter__core__slice__iter__Iter__a__T__next(iter, t,     \
                                                                   ret_t)       \
   (((iter)->index == (iter)->s.len)                                            \
        ? (KRML_CLITERAL(ret_t){.tag = core_option_None})                       \
@@ -441,7 +441,7 @@ typedef const char *Prims_string;
 typedef void *core_fmt_Formatter;
 typedef void *core_fmt_Arguments;
 typedef void *core_fmt_rt_Argument;
-#define core_fmt_rt__core__fmt__rt__Argument__a__1__new_display(x1, x2, x3,    \
+#define core_fmt_rt__core__fmt__rt__Argument__a___new_display(x1, x2, x3,    \
                                                                 x4)            \
   NULL
 

--- a/lib/AstOfLlbc.ml
+++ b/lib/AstOfLlbc.ml
@@ -166,22 +166,11 @@ let assert_slice (t : K.typ) =
 let string_of_path_elem (env : env) (p : Charon.Types.path_elem) : string =
   match p with
   | PeIdent (s, _) -> s
-  | PeImpl (i, d) ->
+  | PeImpl (i, _) ->
       (* The default format changed slightly. This reproduces the old one so as
          not to break existing symbol names. *)
-      let d =
-        if d = Charon.Types.Disambiguator.zero then
-          ""
-        else
-          "#" ^ Charon.Types.Disambiguator.to_string d
-      in
       let i_as_str = Charon.PrintTypes.impl_elem_to_string env.format_env i in
-      let i_as_str =
-        match i with
-        | ImplElemTy _ -> i_as_str
-        | ImplElemTrait _ -> "(" ^ i_as_str ^ ")"
-      in
-      "{" ^ i_as_str ^ d ^ "}"
+      "{" ^ i_as_str ^ "}"
   | PeMonomorphized _ -> Charon.PrintTypes.path_elem_to_string env.format_env p
 
 let string_of_name env ps = String.concat "::" (List.map (string_of_path_elem env) ps)

--- a/out/test-array/array.c
+++ b/out/test-array/array.c
@@ -44,32 +44,32 @@ void array_mut_foo(array_Foo f)
 }
 
 /**
-This function found in impl {(core::ops::function::FnMut<(usize), u32> for array::mk_incr::closure<K>)}
+This function found in impl {core::ops::function::FnMut<(usize), u32> for array::mk_incr::closure<K>}
 */
 /**
-A monomorphic instance of array.mk_incr.call_mut_b4
+A monomorphic instance of array.mk_incr.call_mut_e2
 with const generics
 - K= 10
 */
-uint32_t array_mk_incr_call_mut_b4_95(void **_, size_t tupled_args)
+uint32_t array_mk_incr_call_mut_e2_95(void **_, size_t tupled_args)
 {
   size_t i = tupled_args;
   return (uint32_t)i;
 }
 
 /**
-This function found in impl {(core::ops::function::FnOnce<(usize), u32> for array::mk_incr::closure<K>)}
+This function found in impl {core::ops::function::FnOnce<(usize), u32> for array::mk_incr::closure<K>}
 */
 /**
-A monomorphic instance of array.mk_incr.call_once_9a
+A monomorphic instance of array.mk_incr.call_once_b7
 with const generics
 - K= 10
 */
-uint32_t array_mk_incr_call_once_9a_95(size_t _)
+uint32_t array_mk_incr_call_once_b7_95(size_t _)
 {
   /* original Rust expression is not an lvalue in C */
   void *lvalue = (void *)0U;
-  return array_mk_incr_call_mut_b4_95(&lvalue, _);
+  return array_mk_incr_call_mut_e2_95(&lvalue, _);
 }
 
 /**
@@ -85,34 +85,34 @@ void array_mk_incr_95(uint32_t ret[10U])
     (size_t)1U,
     /* original Rust expression is not an lvalue in C */
     void *lvalue = (void *)0U;
-    ret[i] = array_mk_incr_call_mut_b4_95(&lvalue, i););
+    ret[i] = array_mk_incr_call_mut_e2_95(&lvalue, i););
 }
 
 /**
-This function found in impl {(core::ops::function::FnMut<(usize), u32> for array::mk_incr2::closure<0, K>)}
+This function found in impl {core::ops::function::FnMut<(usize), u32> for array::mk_incr2::closure<0, K>}
 */
 /**
-A monomorphic instance of array.mk_incr2.call_mut_ae
+A monomorphic instance of array.mk_incr2.call_mut_eb
 with const generics
 - K= 10
 */
-uint32_t array_mk_incr2_call_mut_ae_95(uint32_t **_, size_t tupled_args)
+uint32_t array_mk_incr2_call_mut_eb_95(uint32_t **_, size_t tupled_args)
 {
   size_t i = tupled_args;
   return (uint32_t)i + _[0U][0U];
 }
 
 /**
-This function found in impl {(core::ops::function::FnOnce<(usize), u32> for array::mk_incr2::closure<0, K>)}
+This function found in impl {core::ops::function::FnOnce<(usize), u32> for array::mk_incr2::closure<0, K>}
 */
 /**
-A monomorphic instance of array.mk_incr2.call_once_d4
+A monomorphic instance of array.mk_incr2.call_once_ad
 with const generics
 - K= 10
 */
-uint32_t array_mk_incr2_call_once_d4_95(uint32_t *_, size_t _0)
+uint32_t array_mk_incr2_call_once_ad_95(uint32_t *_, size_t _0)
 {
-  return array_mk_incr2_call_mut_ae_95(&_, _0);
+  return array_mk_incr2_call_mut_eb_95(&_, _0);
 }
 
 /**
@@ -130,37 +130,37 @@ void array_mk_incr2_95(uint32_t ret[10U])
     (size_t)1U,
     /* original Rust expression is not an lvalue in C */
     uint32_t *lvalue = &j;
-    ret0[i] = array_mk_incr2_call_mut_ae_95(&lvalue, i););
+    ret0[i] = array_mk_incr2_call_mut_eb_95(&lvalue, i););
   memcpy(ret, ret0, (size_t)10U * sizeof (uint32_t));
 }
 
 /**
-This function found in impl {(core::ops::function::FnMut<(u32), u16> for array::plus_one::closure<K>)}
+This function found in impl {core::ops::function::FnMut<(u32), u16> for array::plus_one::closure<K>}
 */
 /**
-A monomorphic instance of array.plus_one.call_mut_9c
+A monomorphic instance of array.plus_one.call_mut_8d
 with const generics
 - K= 1
 */
-uint16_t array_plus_one_call_mut_9c_74(void **_, uint32_t tupled_args)
+uint16_t array_plus_one_call_mut_8d_74(void **_, uint32_t tupled_args)
 {
   uint32_t x = tupled_args;
   return (uint16_t)(x + 1U);
 }
 
 /**
-This function found in impl {(core::ops::function::FnOnce<(u32), u16> for array::plus_one::closure<K>)}
+This function found in impl {core::ops::function::FnOnce<(u32), u16> for array::plus_one::closure<K>}
 */
 /**
-A monomorphic instance of array.plus_one.call_once_42
+A monomorphic instance of array.plus_one.call_once_36
 with const generics
 - K= 1
 */
-uint16_t array_plus_one_call_once_42_74(uint32_t _)
+uint16_t array_plus_one_call_once_36_74(uint32_t _)
 {
   /* original Rust expression is not an lvalue in C */
   void *lvalue = (void *)0U;
-  return array_plus_one_call_mut_9c_74(&lvalue, _);
+  return array_plus_one_call_mut_8d_74(&lvalue, _);
 }
 
 /**
@@ -177,47 +177,47 @@ void array_plus_one_74(uint32_t x[1U], uint16_t ret[1U])
   {
     /* original Rust expression is not an lvalue in C */
     void *lvalue = (void *)0U;
-    ret0[0U] = array_plus_one_call_mut_9c_74(&lvalue, copy_of_x[0U]);
+    ret0[0U] = array_plus_one_call_mut_8d_74(&lvalue, copy_of_x[0U]);
   }
   memcpy(ret, ret0, (size_t)1U * sizeof (uint16_t));
 }
 
 /**
-This function found in impl {(core::ops::function::FnMut<(usize), usize> for array::nested_from_fn::closure::closure<0, K>)}
+This function found in impl {core::ops::function::FnMut<(usize), usize> for array::nested_from_fn::closure::closure<0, K>}
 */
 /**
-A monomorphic instance of array.nested_from_fn.closure.call_mut_86
+A monomorphic instance of array.nested_from_fn.closure.call_mut_74
 with const generics
 - K= 4
 */
-size_t array_nested_from_fn_closure_call_mut_86_ac(size_t **_, size_t tupled_args)
+size_t array_nested_from_fn_closure_call_mut_74_ac(size_t **_, size_t tupled_args)
 {
   size_t i = tupled_args;
   return i + _[0U][0U];
 }
 
 /**
-This function found in impl {(core::ops::function::FnOnce<(usize), usize> for array::nested_from_fn::closure::closure<0, K>)}
+This function found in impl {core::ops::function::FnOnce<(usize), usize> for array::nested_from_fn::closure::closure<0, K>}
 */
 /**
-A monomorphic instance of array.nested_from_fn.closure.call_once_69
+A monomorphic instance of array.nested_from_fn.closure.call_once_4d
 with const generics
 - K= 4
 */
-size_t array_nested_from_fn_closure_call_once_69_ac(size_t *_, size_t _0)
+size_t array_nested_from_fn_closure_call_once_4d_ac(size_t *_, size_t _0)
 {
-  return array_nested_from_fn_closure_call_mut_86_ac(&_, _0);
+  return array_nested_from_fn_closure_call_mut_74_ac(&_, _0);
 }
 
 /**
-This function found in impl {(core::ops::function::FnMut<(usize), @Array<usize, K>> for array::nested_from_fn::closure<K>)}
+This function found in impl {core::ops::function::FnMut<(usize), @Array<usize, K>> for array::nested_from_fn::closure<K>}
 */
 /**
-A monomorphic instance of array.nested_from_fn.call_mut_ef
+A monomorphic instance of array.nested_from_fn.call_mut_af
 with const generics
 - K= 4
 */
-void array_nested_from_fn_call_mut_ef_ac(void **_, size_t tupled_args, size_t ret[4U])
+void array_nested_from_fn_call_mut_af_ac(void **_, size_t tupled_args, size_t ret[4U])
 {
   size_t j = tupled_args;
   size_t ret0[4U];
@@ -227,23 +227,23 @@ void array_nested_from_fn_call_mut_ef_ac(void **_, size_t tupled_args, size_t re
     (size_t)1U,
     /* original Rust expression is not an lvalue in C */
     size_t *lvalue = &j;
-    ret0[i] = array_nested_from_fn_closure_call_mut_86_ac(&lvalue, i););
+    ret0[i] = array_nested_from_fn_closure_call_mut_74_ac(&lvalue, i););
   memcpy(ret, ret0, (size_t)4U * sizeof (size_t));
 }
 
 /**
-This function found in impl {(core::ops::function::FnOnce<(usize), @Array<usize, K>> for array::nested_from_fn::closure<K>)}
+This function found in impl {core::ops::function::FnOnce<(usize), @Array<usize, K>> for array::nested_from_fn::closure<K>}
 */
 /**
-A monomorphic instance of array.nested_from_fn.call_once_e9
+A monomorphic instance of array.nested_from_fn.call_once_f6
 with const generics
 - K= 4
 */
-void array_nested_from_fn_call_once_e9_ac(size_t _, size_t ret[4U])
+void array_nested_from_fn_call_once_f6_ac(size_t _, size_t ret[4U])
 {
   /* original Rust expression is not an lvalue in C */
   void *lvalue = (void *)0U;
-  array_nested_from_fn_call_mut_ef_ac(&lvalue, _, ret);
+  array_nested_from_fn_call_mut_af_ac(&lvalue, _, ret);
 }
 
 /**
@@ -259,7 +259,7 @@ void array_nested_from_fn_ac(size_t ret[4U][4U])
     (size_t)1U,
     /* original Rust expression is not an lvalue in C */
     void *lvalue = (void *)0U;
-    array_nested_from_fn_call_mut_ef_ac(&lvalue, i, ret[i]););
+    array_nested_from_fn_call_mut_af_ac(&lvalue, i, ret[i]););
 }
 
 typedef struct _uint32_t__x2_s

--- a/out/test-array/array.h
+++ b/out/test-array/array.h
@@ -37,24 +37,24 @@ void array_mut_array(uint32_t x[2U]);
 void array_mut_foo(array_Foo f);
 
 /**
-This function found in impl {(core::ops::function::FnMut<(usize), u32> for array::mk_incr::closure<K>)}
+This function found in impl {core::ops::function::FnMut<(usize), u32> for array::mk_incr::closure<K>}
 */
 /**
-A monomorphic instance of array.mk_incr.call_mut_b4
+A monomorphic instance of array.mk_incr.call_mut_e2
 with const generics
 - K= 10
 */
-uint32_t array_mk_incr_call_mut_b4_95(void **_, size_t tupled_args);
+uint32_t array_mk_incr_call_mut_e2_95(void **_, size_t tupled_args);
 
 /**
-This function found in impl {(core::ops::function::FnOnce<(usize), u32> for array::mk_incr::closure<K>)}
+This function found in impl {core::ops::function::FnOnce<(usize), u32> for array::mk_incr::closure<K>}
 */
 /**
-A monomorphic instance of array.mk_incr.call_once_9a
+A monomorphic instance of array.mk_incr.call_once_b7
 with const generics
 - K= 10
 */
-uint32_t array_mk_incr_call_once_9a_95(size_t _);
+uint32_t array_mk_incr_call_once_b7_95(size_t _);
 
 /**
 A monomorphic instance of array.mk_incr
@@ -71,24 +71,24 @@ with const generics
 typedef uint32_t *array_mk_incr2_closure_40;
 
 /**
-This function found in impl {(core::ops::function::FnMut<(usize), u32> for array::mk_incr2::closure<0, K>)}
+This function found in impl {core::ops::function::FnMut<(usize), u32> for array::mk_incr2::closure<0, K>}
 */
 /**
-A monomorphic instance of array.mk_incr2.call_mut_ae
+A monomorphic instance of array.mk_incr2.call_mut_eb
 with const generics
 - K= 10
 */
-uint32_t array_mk_incr2_call_mut_ae_95(uint32_t **_, size_t tupled_args);
+uint32_t array_mk_incr2_call_mut_eb_95(uint32_t **_, size_t tupled_args);
 
 /**
-This function found in impl {(core::ops::function::FnOnce<(usize), u32> for array::mk_incr2::closure<0, K>)}
+This function found in impl {core::ops::function::FnOnce<(usize), u32> for array::mk_incr2::closure<0, K>}
 */
 /**
-A monomorphic instance of array.mk_incr2.call_once_d4
+A monomorphic instance of array.mk_incr2.call_once_ad
 with const generics
 - K= 10
 */
-uint32_t array_mk_incr2_call_once_d4_95(uint32_t *_, size_t _0);
+uint32_t array_mk_incr2_call_once_ad_95(uint32_t *_, size_t _0);
 
 /**
 A monomorphic instance of array.mk_incr2
@@ -98,24 +98,24 @@ with const generics
 void array_mk_incr2_95(uint32_t ret[10U]);
 
 /**
-This function found in impl {(core::ops::function::FnMut<(u32), u16> for array::plus_one::closure<K>)}
+This function found in impl {core::ops::function::FnMut<(u32), u16> for array::plus_one::closure<K>}
 */
 /**
-A monomorphic instance of array.plus_one.call_mut_9c
+A monomorphic instance of array.plus_one.call_mut_8d
 with const generics
 - K= 1
 */
-uint16_t array_plus_one_call_mut_9c_74(void **_, uint32_t tupled_args);
+uint16_t array_plus_one_call_mut_8d_74(void **_, uint32_t tupled_args);
 
 /**
-This function found in impl {(core::ops::function::FnOnce<(u32), u16> for array::plus_one::closure<K>)}
+This function found in impl {core::ops::function::FnOnce<(u32), u16> for array::plus_one::closure<K>}
 */
 /**
-A monomorphic instance of array.plus_one.call_once_42
+A monomorphic instance of array.plus_one.call_once_36
 with const generics
 - K= 1
 */
-uint16_t array_plus_one_call_once_42_74(uint32_t _);
+uint16_t array_plus_one_call_once_36_74(uint32_t _);
 
 /**
 A monomorphic instance of array.plus_one
@@ -132,44 +132,44 @@ with const generics
 typedef size_t *array_nested_from_fn_closure_closure_44;
 
 /**
-This function found in impl {(core::ops::function::FnMut<(usize), usize> for array::nested_from_fn::closure::closure<0, K>)}
+This function found in impl {core::ops::function::FnMut<(usize), usize> for array::nested_from_fn::closure::closure<0, K>}
 */
 /**
-A monomorphic instance of array.nested_from_fn.closure.call_mut_86
+A monomorphic instance of array.nested_from_fn.closure.call_mut_74
 with const generics
 - K= 4
 */
-size_t array_nested_from_fn_closure_call_mut_86_ac(size_t **_, size_t tupled_args);
+size_t array_nested_from_fn_closure_call_mut_74_ac(size_t **_, size_t tupled_args);
 
 /**
-This function found in impl {(core::ops::function::FnOnce<(usize), usize> for array::nested_from_fn::closure::closure<0, K>)}
+This function found in impl {core::ops::function::FnOnce<(usize), usize> for array::nested_from_fn::closure::closure<0, K>}
 */
 /**
-A monomorphic instance of array.nested_from_fn.closure.call_once_69
+A monomorphic instance of array.nested_from_fn.closure.call_once_4d
 with const generics
 - K= 4
 */
-size_t array_nested_from_fn_closure_call_once_69_ac(size_t *_, size_t _0);
+size_t array_nested_from_fn_closure_call_once_4d_ac(size_t *_, size_t _0);
 
 /**
-This function found in impl {(core::ops::function::FnMut<(usize), @Array<usize, K>> for array::nested_from_fn::closure<K>)}
+This function found in impl {core::ops::function::FnMut<(usize), @Array<usize, K>> for array::nested_from_fn::closure<K>}
 */
 /**
-A monomorphic instance of array.nested_from_fn.call_mut_ef
+A monomorphic instance of array.nested_from_fn.call_mut_af
 with const generics
 - K= 4
 */
-void array_nested_from_fn_call_mut_ef_ac(void **_, size_t tupled_args, size_t ret[4U]);
+void array_nested_from_fn_call_mut_af_ac(void **_, size_t tupled_args, size_t ret[4U]);
 
 /**
-This function found in impl {(core::ops::function::FnOnce<(usize), @Array<usize, K>> for array::nested_from_fn::closure<K>)}
+This function found in impl {core::ops::function::FnOnce<(usize), @Array<usize, K>> for array::nested_from_fn::closure<K>}
 */
 /**
-A monomorphic instance of array.nested_from_fn.call_once_e9
+A monomorphic instance of array.nested_from_fn.call_once_f6
 with const generics
 - K= 4
 */
-void array_nested_from_fn_call_once_e9_ac(size_t _, size_t ret[4U]);
+void array_nested_from_fn_call_once_f6_ac(size_t _, size_t ret[4U]);
 
 /**
 A monomorphic instance of array.nested_from_fn

--- a/out/test-array2d/array2d.c
+++ b/out/test-array2d/array2d.c
@@ -13,7 +13,7 @@ bool array2d_f(uint32_t x[4U][2U])
   x[0U][1U] = 2U;
   uint32_t y[4U][2U] = { { 1U, 2U }, { 3U, 4U }, { 1U, 2U }, { 3U, 4U } };
   return
-    core_array_equality___core__cmp__PartialEq__Array_U__N___for__Array_T__N____eq((size_t)4U,
+    core_array_equality__core__cmp__PartialEq__Array_U__N___for__Array_T__N___eq((size_t)4U,
       x,
       y,
       uint32_t [2U],

--- a/out/test-array2d/array2d.h
+++ b/out/test-array2d/array2d.h
@@ -25,8 +25,7 @@ typedef uint8_t core_panicking_AssertKind;
 
 void array2d_main(void);
 
-extern bool
-core_cmp_impls___core__cmp__PartialEq_u32__for_u32__24__eq(uint32_t *x0, uint32_t *x1);
+extern bool core_cmp_impls__core__cmp__PartialEq_u32__for_u32__eq(uint32_t *x0, uint32_t *x1);
 
 #if defined(__cplusplus)
 }

--- a/out/test-const_generics/const_generics.c
+++ b/out/test-const_generics/const_generics.c
@@ -26,7 +26,7 @@ void const_generics_serialize_3b(Eurydice_slice re, uint8_t ret[8U])
       size_t,
       Eurydice_derefed_slice);
   uint8_t ret0[4U];
-  core_num__u32_8__to_be_bytes(Eurydice_slice_index(re, (size_t)0U, uint32_t, uint32_t *), ret0);
+  core_num__u32__to_be_bytes(Eurydice_slice_index(re, (size_t)0U, uint32_t, uint32_t *), ret0);
   Eurydice_slice_copy(uu____0, Eurydice_array_to_slice((size_t)4U, ret0, uint8_t), uint8_t);
   Eurydice_slice
   uu____1 =
@@ -37,7 +37,7 @@ void const_generics_serialize_3b(Eurydice_slice re, uint8_t ret[8U])
       size_t,
       Eurydice_derefed_slice);
   uint8_t ret1[4U];
-  core_num__u32_8__to_be_bytes(Eurydice_slice_index(re, (size_t)1U, uint32_t, uint32_t *), ret1);
+  core_num__u32__to_be_bytes(Eurydice_slice_index(re, (size_t)1U, uint32_t, uint32_t *), ret1);
   Eurydice_slice_copy(uu____1, Eurydice_array_to_slice((size_t)4U, ret1, uint8_t), uint8_t);
   memcpy(ret, out, (size_t)8U * sizeof (uint8_t));
 }

--- a/out/test-const_generics/const_generics.h
+++ b/out/test-const_generics/const_generics.h
@@ -15,7 +15,7 @@
 extern "C" {
 #endif
 
-static inline void core_num__u32_8__to_be_bytes(uint32_t x0, uint8_t x1[4U]);
+static inline void core_num__u32__to_be_bytes(uint32_t x0, uint8_t x1[4U]);
 
 /**
 A monomorphic instance of const_generics.serialize
@@ -111,11 +111,11 @@ bool const_generics_g_70(uint32_t x, size_t y);
 
 void const_generics_main3(void);
 
-extern uint32_t core_clone_impls___core__clone__Clone_for_u32__8__clone(uint32_t *x0);
+extern uint32_t core_clone_impls__core__clone__Clone_for_u32__clone(uint32_t *x0);
 
-extern uint64_t core_clone_impls___core__clone__Clone_for_u64__9__clone(uint64_t *x0);
+extern uint64_t core_clone_impls__core__clone__Clone_for_u64__clone(uint64_t *x0);
 
-extern uint8_t core_clone_impls___core__clone__Clone_for_u8__6__clone(uint8_t *x0);
+extern uint8_t core_clone_impls__core__clone__Clone_for_u8__clone(uint8_t *x0);
 
 #if defined(__cplusplus)
 }

--- a/out/test-fn_higher_order/fn_higher_order.h
+++ b/out/test-fn_higher_order/fn_higher_order.h
@@ -15,9 +15,9 @@
 extern "C" {
 #endif
 
-extern int32_t core_clone_impls___core__clone__Clone_for_i32__14__clone(int32_t *x0);
+extern int32_t core_clone_impls__core__clone__Clone_for_i32__clone(int32_t *x0);
 
-extern size_t core_clone_impls___core__clone__Clone_for_usize__5__clone(size_t *x0);
+extern size_t core_clone_impls__core__clone__Clone_for_usize__clone(size_t *x0);
 
 #define core_cmp_Ordering_Less -1
 #define core_cmp_Ordering_Equal 0
@@ -25,8 +25,7 @@ extern size_t core_clone_impls___core__clone__Clone_for_usize__5__clone(size_t *
 
 typedef int8_t core_cmp_Ordering;
 
-extern bool
-core_cmp_impls___core__cmp__PartialEq_usize__for_usize__21__eq(size_t *x0, size_t *x1);
+extern bool core_cmp_impls__core__cmp__PartialEq_usize__for_usize__eq(size_t *x0, size_t *x1);
 
 #define core_option_None 0
 #define core_option_Some 1
@@ -46,10 +45,7 @@ typedef struct core_option_Option_77_s
 core_option_Option_77;
 
 extern core_option_Option_77
-core_cmp_impls___core__cmp__PartialOrd_usize__for_usize__58__partial_cmp(
-  size_t *x0,
-  size_t *x1
-);
+core_cmp_impls__core__cmp__PartialOrd_usize__for_usize__partial_cmp(size_t *x0, size_t *x1);
 
 /**
 A monomorphic instance of core.option.Option
@@ -64,10 +60,10 @@ typedef struct core_option_Option_08_s
 core_option_Option_08;
 
 extern core_option_Option_08
-core_iter_range___core__iter__range__Step_for_usize__43__backward_checked(size_t x0, size_t x1);
+core_iter_range__core__iter__range__Step_for_usize__backward_checked(size_t x0, size_t x1);
 
 extern core_option_Option_08
-core_iter_range___core__iter__range__Step_for_usize__43__forward_checked(size_t x0, size_t x1);
+core_iter_range__core__iter__range__Step_for_usize__forward_checked(size_t x0, size_t x1);
 
 /**
 A monomorphic instance of K.
@@ -82,7 +78,7 @@ typedef struct tuple_04_s
 tuple_04;
 
 extern tuple_04
-core_iter_range___core__iter__range__Step_for_usize__43__steps_between(size_t *x0, size_t *x1);
+core_iter_range__core__iter__range__Step_for_usize__steps_between(size_t *x0, size_t *x1);
 
 #define core_panicking_AssertKind_Eq 0
 #define core_panicking_AssertKind_Ne 1

--- a/out/test-issue_104/issue_104.c
+++ b/out/test-issue_104/issue_104.c
@@ -15,7 +15,7 @@ with const generics
 */
 uint8_t issue_104_sth_50(void)
 {
-  return ISSUE_104___ISSUE_104__FUN_FOR_ISSUE_104__S___VAL;
+  return ISSUE_104__ISSUE_104__FUN_FOR_ISSUE_104__S__VAL;
 }
 
 uint8_t issue_104_call(void)

--- a/out/test-issue_104/issue_104.h
+++ b/out/test-issue_104/issue_104.h
@@ -21,7 +21,7 @@ extern "C" {
 
 typedef uint8_t core_panicking_AssertKind;
 
-#define ISSUE_104___ISSUE_104__FUN_FOR_ISSUE_104__S___VAL (5U)
+#define ISSUE_104__ISSUE_104__FUN_FOR_ISSUE_104__S__VAL (5U)
 
 /**
 A monomorphic instance of issue_104.sth

--- a/out/test-issue_107/issue_107.c
+++ b/out/test-issue_107/issue_107.c
@@ -13,9 +13,9 @@ void issue_107_main(void)
 }
 
 /**
-This function found in impl {(issue_107::Fun for issue_107::MyStruct)}
+This function found in impl {issue_107::Fun for issue_107::MyStruct}
 */
-uint8_t issue_107_f_18(void)
+uint8_t issue_107_f_90(void)
 {
   return 5U;
 }

--- a/out/test-issue_107/issue_107.h
+++ b/out/test-issue_107/issue_107.h
@@ -18,9 +18,9 @@ extern "C" {
 void issue_107_main(void);
 
 /**
-This function found in impl {(issue_107::Fun for issue_107::MyStruct)}
+This function found in impl {issue_107::Fun for issue_107::MyStruct}
 */
-uint8_t issue_107_f_18(void);
+uint8_t issue_107_f_90(void);
 
 #if defined(__cplusplus)
 }

--- a/out/test-issue_123/issue_123.c
+++ b/out/test-issue_123/issue_123.c
@@ -58,9 +58,9 @@ void issue_123_main(void)
 }
 
 /**
-This function found in impl {(core::cmp::PartialEq<issue_123::E2> for issue_123::E2)#1}
+This function found in impl {core::cmp::PartialEq<issue_123::E2> for issue_123::E2}
 */
-inline bool issue_123_eq_87(issue_123_E2 *self, issue_123_E2 *other)
+inline bool issue_123_eq_e3(issue_123_E2 *self, issue_123_E2 *other)
 {
   ptrdiff_t __self_discr;
   if (self[0U] == issue_123_E2_C1)

--- a/out/test-issue_123/issue_123.h
+++ b/out/test-issue_123/issue_123.h
@@ -56,9 +56,9 @@ int32_t issue_123_fun(issue_123_E e);
 void issue_123_main(void);
 
 /**
-This function found in impl {(core::cmp::PartialEq<issue_123::E2> for issue_123::E2)#1}
+This function found in impl {core::cmp::PartialEq<issue_123::E2> for issue_123::E2}
 */
-bool issue_123_eq_87(issue_123_E2 *self, issue_123_E2 *other);
+bool issue_123_eq_e3(issue_123_E2 *self, issue_123_E2 *other);
 
 #if defined(__cplusplus)
 }

--- a/out/test-issue_49/issue_49.c
+++ b/out/test-issue_49/issue_49.c
@@ -9,7 +9,7 @@
 
 size_t issue_49_f(size_t a, size_t b)
 {
-  return core_cmp_impls___core__cmp__Ord_for_usize__59__min(a, b);
+  return core_cmp_impls__core__cmp__Ord_for_usize__min(a, b);
 }
 
 typedef struct _size_t__x2_s

--- a/out/test-issue_49/issue_49.h
+++ b/out/test-issue_49/issue_49.h
@@ -38,19 +38,14 @@ typedef struct core_option_Option_77_s
 }
 core_option_Option_77;
 
-extern core_cmp_Ordering
-core_cmp_impls___core__cmp__Ord_for_usize__59__cmp(size_t *x0, size_t *x1);
+extern core_cmp_Ordering core_cmp_impls__core__cmp__Ord_for_usize__cmp(size_t *x0, size_t *x1);
 
-extern size_t core_cmp_impls___core__cmp__Ord_for_usize__59__min(size_t x0, size_t x1);
+extern size_t core_cmp_impls__core__cmp__Ord_for_usize__min(size_t x0, size_t x1);
 
-extern bool
-core_cmp_impls___core__cmp__PartialEq_usize__for_usize__21__eq(size_t *x0, size_t *x1);
+extern bool core_cmp_impls__core__cmp__PartialEq_usize__for_usize__eq(size_t *x0, size_t *x1);
 
 extern core_option_Option_77
-core_cmp_impls___core__cmp__PartialOrd_usize__for_usize__58__partial_cmp(
-  size_t *x0,
-  size_t *x1
-);
+core_cmp_impls__core__cmp__PartialOrd_usize__for_usize__partial_cmp(size_t *x0, size_t *x1);
 
 #define core_panicking_AssertKind_Eq 0
 #define core_panicking_AssertKind_Ne 1

--- a/out/test-nested_arrays/nested_arrays.h
+++ b/out/test-nested_arrays/nested_arrays.h
@@ -15,7 +15,7 @@
 extern "C" {
 #endif
 
-extern size_t core_clone_impls___core__clone__Clone_for_usize__5__clone(size_t *x0);
+extern size_t core_clone_impls__core__clone__Clone_for_usize__clone(size_t *x0);
 
 #define core_cmp_Ordering_Less -1
 #define core_cmp_Ordering_Equal 0
@@ -23,8 +23,7 @@ extern size_t core_clone_impls___core__clone__Clone_for_usize__5__clone(size_t *
 
 typedef int8_t core_cmp_Ordering;
 
-extern bool
-core_cmp_impls___core__cmp__PartialEq_usize__for_usize__21__eq(size_t *x0, size_t *x1);
+extern bool core_cmp_impls__core__cmp__PartialEq_usize__for_usize__eq(size_t *x0, size_t *x1);
 
 #define core_option_None 0
 #define core_option_Some 1
@@ -44,10 +43,7 @@ typedef struct core_option_Option_77_s
 core_option_Option_77;
 
 extern core_option_Option_77
-core_cmp_impls___core__cmp__PartialOrd_usize__for_usize__58__partial_cmp(
-  size_t *x0,
-  size_t *x1
-);
+core_cmp_impls__core__cmp__PartialOrd_usize__for_usize__partial_cmp(size_t *x0, size_t *x1);
 
 /**
 A monomorphic instance of core.option.Option
@@ -62,10 +58,10 @@ typedef struct core_option_Option_08_s
 core_option_Option_08;
 
 extern core_option_Option_08
-core_iter_range___core__iter__range__Step_for_usize__43__backward_checked(size_t x0, size_t x1);
+core_iter_range__core__iter__range__Step_for_usize__backward_checked(size_t x0, size_t x1);
 
 extern core_option_Option_08
-core_iter_range___core__iter__range__Step_for_usize__43__forward_checked(size_t x0, size_t x1);
+core_iter_range__core__iter__range__Step_for_usize__forward_checked(size_t x0, size_t x1);
 
 /**
 A monomorphic instance of K.
@@ -80,7 +76,7 @@ typedef struct tuple_04_s
 tuple_04;
 
 extern tuple_04
-core_iter_range___core__iter__range__Step_for_usize__43__steps_between(size_t *x0, size_t *x1);
+core_iter_range__core__iter__range__Step_for_usize__steps_between(size_t *x0, size_t *x1);
 
 #define core_panicking_AssertKind_Eq 0
 #define core_panicking_AssertKind_Ne 1

--- a/out/test-partial_eq/partial_eq.c
+++ b/out/test-partial_eq/partial_eq.c
@@ -10,9 +10,9 @@
 #include "Eurydice.h"
 
 /**
-This function found in impl {(core::cmp::PartialEq<partial_eq::Enum> for partial_eq::Enum)#1}
+This function found in impl {core::cmp::PartialEq<partial_eq::Enum> for partial_eq::Enum}
 */
-inline bool partial_eq_eq_dd(partial_eq_Enum *self, partial_eq_Enum *other)
+inline bool partial_eq_eq_31(partial_eq_Enum *self, partial_eq_Enum *other)
 {
   return true;
 }
@@ -30,16 +30,16 @@ void partial_eq_main(void)
   _partial_eq_Enum__x2 uu____0 = { .fst = &expected, .snd = &expected };
   partial_eq_Enum *left_val = uu____0.fst;
   partial_eq_Enum *right_val = uu____0.snd;
-  EURYDICE_ASSERT(partial_eq_eq_dd(left_val, right_val), "panic!");
+  EURYDICE_ASSERT(partial_eq_eq_31(left_val, right_val), "panic!");
 }
 
 /**
-This function found in impl {(core::fmt::Debug for partial_eq::Enum)#2}
+This function found in impl {core::fmt::Debug for partial_eq::Enum}
 */
-inline core_result_Result_10 partial_eq_fmt_19(partial_eq_Enum *self, core_fmt_Formatter *f)
+inline core_result_Result_10 partial_eq_fmt_29(partial_eq_Enum *self, core_fmt_Formatter *f)
 {
   return
-    core_fmt__core__fmt__Formatter__a__11__write_str(f,
+    core_fmt__core__fmt__Formatter__a___write_str(f,
       (KRML_CLITERAL(Eurydice_str){ .data = "A", .len = (size_t)1U }));
 }
 

--- a/out/test-partial_eq/partial_eq.h
+++ b/out/test-partial_eq/partial_eq.h
@@ -23,7 +23,7 @@ extern "C" {
 typedef uint8_t core_result_Result_10;
 
 extern core_result_Result_10
-core_fmt__core__fmt__Formatter__a__11__write_str(core_fmt_Formatter *x0, Eurydice_str x1);
+core_fmt__core__fmt__Formatter__a___write_str(core_fmt_Formatter *x0, Eurydice_str x1);
 
 #define core_panicking_AssertKind_Eq 0
 #define core_panicking_AssertKind_Ne 1
@@ -36,16 +36,16 @@ typedef uint8_t core_panicking_AssertKind;
 typedef uint8_t partial_eq_Enum;
 
 /**
-This function found in impl {(core::cmp::PartialEq<partial_eq::Enum> for partial_eq::Enum)#1}
+This function found in impl {core::cmp::PartialEq<partial_eq::Enum> for partial_eq::Enum}
 */
-bool partial_eq_eq_dd(partial_eq_Enum *self, partial_eq_Enum *other);
+bool partial_eq_eq_31(partial_eq_Enum *self, partial_eq_Enum *other);
 
 void partial_eq_main(void);
 
 /**
-This function found in impl {(core::fmt::Debug for partial_eq::Enum)#2}
+This function found in impl {core::fmt::Debug for partial_eq::Enum}
 */
-core_result_Result_10 partial_eq_fmt_19(partial_eq_Enum *self, core_fmt_Formatter *f);
+core_result_Result_10 partial_eq_fmt_29(partial_eq_Enum *self, core_fmt_Formatter *f);
 
 #if defined(__cplusplus)
 }

--- a/out/test-step_by/step_by.h
+++ b/out/test-step_by/step_by.h
@@ -15,7 +15,7 @@
 extern "C" {
 #endif
 
-extern int32_t core_clone_impls___core__clone__Clone_for_i32__14__clone(int32_t *x0);
+extern int32_t core_clone_impls__core__clone__Clone_for_i32__clone(int32_t *x0);
 
 #define core_cmp_Ordering_Less -1
 #define core_cmp_Ordering_Equal 0
@@ -23,8 +23,7 @@ extern int32_t core_clone_impls___core__clone__Clone_for_i32__14__clone(int32_t 
 
 typedef int8_t core_cmp_Ordering;
 
-extern bool
-core_cmp_impls___core__cmp__PartialEq_i32__for_i32__30__eq(int32_t *x0, int32_t *x1);
+extern bool core_cmp_impls__core__cmp__PartialEq_i32__for_i32__eq(int32_t *x0, int32_t *x1);
 
 #define core_option_None 0
 #define core_option_Some 1
@@ -44,7 +43,7 @@ typedef struct core_option_Option_77_s
 core_option_Option_77;
 
 extern core_option_Option_77
-core_cmp_impls___core__cmp__PartialOrd_i32__for_i32__76__partial_cmp(int32_t *x0, int32_t *x1);
+core_cmp_impls__core__cmp__PartialOrd_i32__for_i32__partial_cmp(int32_t *x0, int32_t *x1);
 
 /**
 A monomorphic instance of core.option.Option
@@ -59,10 +58,10 @@ typedef struct core_option_Option_9e_s
 core_option_Option_9e;
 
 extern core_option_Option_9e
-core_iter_range___core__iter__range__Step_for_i32__40__backward_checked(int32_t x0, size_t x1);
+core_iter_range__core__iter__range__Step_for_i32__backward_checked(int32_t x0, size_t x1);
 
 extern core_option_Option_9e
-core_iter_range___core__iter__range__Step_for_i32__40__forward_checked(int32_t x0, size_t x1);
+core_iter_range__core__iter__range__Step_for_i32__forward_checked(int32_t x0, size_t x1);
 
 /**
 A monomorphic instance of core.option.Option
@@ -89,7 +88,7 @@ typedef struct tuple_04_s
 tuple_04;
 
 extern tuple_04
-core_iter_range___core__iter__range__Step_for_i32__40__steps_between(int32_t *x0, int32_t *x1);
+core_iter_range__core__iter__range__Step_for_i32__steps_between(int32_t *x0, int32_t *x1);
 
 #define core_panicking_AssertKind_Eq 0
 #define core_panicking_AssertKind_Ne 1

--- a/out/test-symcrust/symcrust.c
+++ b/out/test-symcrust/symcrust.c
@@ -55,7 +55,7 @@ symcrust_SymCrustMlKemPolyElementCompressAndEncode(
         Eurydice_slice
         uu____0 = Eurydice_slice_subslice2(dst, cbDstWritten, cbDstWritten + (size_t)4U, uint8_t);
         uint8_t ret[4U];
-        core_num__u32_8__to_le_bytes(accumulator, ret);
+        core_num__u32__to_le_bytes(accumulator, ret);
         Eurydice_slice_copy(uu____0, Eurydice_array_to_slice((size_t)4U, ret, uint8_t), uint8_t);
         cbDstWritten = cbDstWritten + (size_t)4U;
         accumulator = 0U;

--- a/out/test-symcrust/symcrust.h
+++ b/out/test-symcrust/symcrust.h
@@ -17,9 +17,9 @@ extern "C" {
 
 #include "Eurydice.h"
 
-extern uint8_t core_clone_impls___core__clone__Clone_for_u8__6__clone(uint8_t *x0);
+extern uint8_t core_clone_impls__core__clone__Clone_for_u8__clone(uint8_t *x0);
 
-extern size_t core_clone_impls___core__clone__Clone_for_usize__5__clone(size_t *x0);
+extern size_t core_clone_impls__core__clone__Clone_for_usize__clone(size_t *x0);
 
 #define core_cmp_Ordering_Less -1
 #define core_cmp_Ordering_Equal 0
@@ -45,33 +45,23 @@ typedef struct core_option_Option_77_s
 core_option_Option_77;
 
 extern core_cmp_Ordering
-core_cmp_impls___core__cmp__Ord_for_u32__65__cmp(uint32_t *x0, uint32_t *x1);
+core_cmp_impls__core__cmp__Ord_for_u32__cmp(uint32_t *x0, uint32_t *x1);
 
-extern uint32_t core_cmp_impls___core__cmp__Ord_for_u32__65__min(uint32_t x0, uint32_t x1);
+extern uint32_t core_cmp_impls__core__cmp__Ord_for_u32__min(uint32_t x0, uint32_t x1);
 
-extern bool
-core_cmp_impls___core__cmp__PartialEq_u32__for_u32__24__eq(uint32_t *x0, uint32_t *x1);
+extern bool core_cmp_impls__core__cmp__PartialEq_u32__for_u32__eq(uint32_t *x0, uint32_t *x1);
 
-extern bool
-core_cmp_impls___core__cmp__PartialEq_usize__for_usize__21__eq(size_t *x0, size_t *x1);
+extern bool core_cmp_impls__core__cmp__PartialEq_usize__for_usize__eq(size_t *x0, size_t *x1);
 
 extern core_option_Option_77
-core_cmp_impls___core__cmp__PartialOrd_u32__for_u32__64__partial_cmp(
-  uint32_t *x0,
-  uint32_t *x1
-);
+core_cmp_impls__core__cmp__PartialOrd_u32__for_u32__partial_cmp(uint32_t *x0, uint32_t *x1);
 
 extern core_option_Option_77
-core_cmp_impls___core__cmp__PartialOrd_usize__for_usize__58__partial_cmp(
-  size_t *x0,
-  size_t *x1
-);
+core_cmp_impls__core__cmp__PartialOrd_usize__for_usize__partial_cmp(size_t *x0, size_t *x1);
 
-static inline uint32_t
-core_convert_num___core__convert__From_u16__for_u32__69__from(uint16_t x0);
+static inline uint32_t core_convert_num__core__convert__From_u16__for_u32__from(uint16_t x0);
 
-static inline uint64_t
-core_convert_num___core__convert__From_u32__for_u64__72__from(uint32_t x0);
+static inline uint64_t core_convert_num__core__convert__From_u32__for_u64__from(uint32_t x0);
 
 /**
 A monomorphic instance of core.option.Option
@@ -86,10 +76,10 @@ typedef struct core_option_Option_08_s
 core_option_Option_08;
 
 extern core_option_Option_08
-core_iter_range___core__iter__range__Step_for_usize__43__backward_checked(size_t x0, size_t x1);
+core_iter_range__core__iter__range__Step_for_usize__backward_checked(size_t x0, size_t x1);
 
 extern core_option_Option_08
-core_iter_range___core__iter__range__Step_for_usize__43__forward_checked(size_t x0, size_t x1);
+core_iter_range__core__iter__range__Step_for_usize__forward_checked(size_t x0, size_t x1);
 
 /**
 A monomorphic instance of K.
@@ -104,9 +94,9 @@ typedef struct tuple_04_s
 tuple_04;
 
 extern tuple_04
-core_iter_range___core__iter__range__Step_for_usize__43__steps_between(size_t *x0, size_t *x1);
+core_iter_range__core__iter__range__Step_for_usize__steps_between(size_t *x0, size_t *x1);
 
-static inline void core_num__u32_8__to_le_bytes(uint32_t x0, uint8_t x1[4U]);
+static inline void core_num__u32__to_le_bytes(uint32_t x0, uint8_t x1[4U]);
 
 void
 symcrust_SymCrustMlKemPolyElementCompressAndEncode(

--- a/out/test-trait_generics/trait_generics.c
+++ b/out/test-trait_generics/trait_generics.c
@@ -8,14 +8,14 @@
 #include "trait_generics.h"
 
 /**
-This function found in impl {(trait_generics::MyFnOnce for trait_generics::Foo<K>)}
+This function found in impl {trait_generics::MyFnOnce for trait_generics::Foo<K>}
 */
 /**
-A monomorphic instance of trait_generics.call_once_dc
+A monomorphic instance of trait_generics.call_once_a3
 with const generics
 - K= 10
 */
-uint32_t trait_generics_call_once_dc_95(void)
+uint32_t trait_generics_call_once_a3_95(void)
 {
   return 0U;
 }
@@ -28,7 +28,7 @@ with const generics
 */
 void trait_generics_from_fn_3c(void)
 {
-  LowStar_Ignore_ignore(trait_generics_call_once_dc_95(), uint32_t, void *);
+  LowStar_Ignore_ignore(trait_generics_call_once_a3_95(), uint32_t, void *);
 }
 
 void trait_generics_main(void)

--- a/out/test-trait_generics/trait_generics.h
+++ b/out/test-trait_generics/trait_generics.h
@@ -16,14 +16,14 @@ extern "C" {
 #endif
 
 /**
-This function found in impl {(trait_generics::MyFnOnce for trait_generics::Foo<K>)}
+This function found in impl {trait_generics::MyFnOnce for trait_generics::Foo<K>}
 */
 /**
-A monomorphic instance of trait_generics.call_once_dc
+A monomorphic instance of trait_generics.call_once_a3
 with const generics
 - K= 10
 */
-uint32_t trait_generics_call_once_dc_95(void);
+uint32_t trait_generics_call_once_a3_95(void);
 
 /**
 A monomorphic instance of trait_generics.from_fn

--- a/out/test-traits/traits.c
+++ b/out/test-traits/traits.c
@@ -10,9 +10,9 @@
 #include "Eurydice.h"
 
 /**
-This function found in impl {(traits::ToInt for traits::Foo)}
+This function found in impl {traits::ToInt for traits::Foo}
 */
-uint32_t traits_to_int_7d(traits_Foo *self)
+uint32_t traits_to_int_ac(traits_Foo *self)
 {
   if (!(self[0U] == traits_Foo_Foo1))
   {
@@ -22,16 +22,16 @@ uint32_t traits_to_int_7d(traits_Foo *self)
 }
 
 /**
-This function found in impl {(traits::ToInt for &0 (@Slice<traits::Foo>))#1}
+This function found in impl {traits::ToInt for &0 (@Slice<traits::Foo>)}
 */
-uint32_t traits_to_int_dd(Eurydice_slice *self)
+uint32_t traits_to_int_88(Eurydice_slice *self)
 {
   uint32_t
   uu____0 =
-    traits_to_int_7d(&Eurydice_slice_index(self[0U], (size_t)0U, traits_Foo, traits_Foo *));
+    traits_to_int_ac(&Eurydice_slice_index(self[0U], (size_t)0U, traits_Foo, traits_Foo *));
   return
     uu____0 *
-      traits_to_int_7d(&Eurydice_slice_index(self[0U], (size_t)1U, traits_Foo, traits_Foo *));
+      traits_to_int_ac(&Eurydice_slice_index(self[0U], (size_t)1U, traits_Foo, traits_Foo *));
 }
 
 void traits_main(void)
@@ -39,7 +39,7 @@ void traits_main(void)
   traits_Foo foos[2U] = { traits_Foo_Foo1, traits_Foo_Foo2 };
   /* original Rust expression is not an lvalue in C */
   Eurydice_slice lvalue = Eurydice_array_to_subslice2(foos, (size_t)0U, (size_t)2U, traits_Foo);
-  if (!(traits_to_int_dd(&lvalue) != 2U))
+  if (!(traits_to_int_88(&lvalue) != 2U))
   {
     return;
   }

--- a/out/test-traits/traits.h
+++ b/out/test-traits/traits.h
@@ -23,14 +23,14 @@ extern "C" {
 typedef uint8_t traits_Foo;
 
 /**
-This function found in impl {(traits::ToInt for traits::Foo)}
+This function found in impl {traits::ToInt for traits::Foo}
 */
-uint32_t traits_to_int_7d(traits_Foo *self);
+uint32_t traits_to_int_ac(traits_Foo *self);
 
 /**
-This function found in impl {(traits::ToInt for &0 (@Slice<traits::Foo>))#1}
+This function found in impl {traits::ToInt for &0 (@Slice<traits::Foo>)}
 */
-uint32_t traits_to_int_dd(Eurydice_slice *self);
+uint32_t traits_to_int_88(Eurydice_slice *self);
 
 void traits_main(void);
 

--- a/out/test-traits2/traits2.h
+++ b/out/test-traits2/traits2.h
@@ -17,7 +17,7 @@ extern "C" {
 
 #include "Eurydice.h"
 
-extern size_t core_clone_impls___core__clone__Clone_for_usize__5__clone(size_t *x0);
+extern size_t core_clone_impls__core__clone__Clone_for_usize__clone(size_t *x0);
 
 #define core_cmp_Ordering_Less -1
 #define core_cmp_Ordering_Equal 0
@@ -25,8 +25,7 @@ extern size_t core_clone_impls___core__clone__Clone_for_usize__5__clone(size_t *
 
 typedef int8_t core_cmp_Ordering;
 
-extern bool
-core_cmp_impls___core__cmp__PartialEq_usize__for_usize__21__eq(size_t *x0, size_t *x1);
+extern bool core_cmp_impls__core__cmp__PartialEq_usize__for_usize__eq(size_t *x0, size_t *x1);
 
 #define core_option_None 0
 #define core_option_Some 1
@@ -46,10 +45,7 @@ typedef struct core_option_Option_77_s
 core_option_Option_77;
 
 extern core_option_Option_77
-core_cmp_impls___core__cmp__PartialOrd_usize__for_usize__58__partial_cmp(
-  size_t *x0,
-  size_t *x1
-);
+core_cmp_impls__core__cmp__PartialOrd_usize__for_usize__partial_cmp(size_t *x0, size_t *x1);
 
 /**
 A monomorphic instance of core.option.Option
@@ -64,10 +60,10 @@ typedef struct core_option_Option_08_s
 core_option_Option_08;
 
 extern core_option_Option_08
-core_iter_range___core__iter__range__Step_for_usize__43__backward_checked(size_t x0, size_t x1);
+core_iter_range__core__iter__range__Step_for_usize__backward_checked(size_t x0, size_t x1);
 
 extern core_option_Option_08
-core_iter_range___core__iter__range__Step_for_usize__43__forward_checked(size_t x0, size_t x1);
+core_iter_range__core__iter__range__Step_for_usize__forward_checked(size_t x0, size_t x1);
 
 /**
 A monomorphic instance of K.
@@ -82,7 +78,7 @@ typedef struct tuple_04_s
 tuple_04;
 
 extern tuple_04
-core_iter_range___core__iter__range__Step_for_usize__43__steps_between(size_t *x0, size_t *x1);
+core_iter_range__core__iter__range__Step_for_usize__steps_between(size_t *x0, size_t *x1);
 
 void traits2_main(void);
 

--- a/out/test-traits3/traits3.c
+++ b/out/test-traits3/traits3.c
@@ -8,9 +8,9 @@
 #include "traits3.h"
 
 /**
-This function found in impl {(traits3::internal::KeccakItem<2: usize> for (u64, u64))#1}
+This function found in impl {traits3::internal::KeccakItem<2: usize> for (u64, u64)}
 */
-uint64_t_x2 traits3_zero_f1(void)
+uint64_t_x2 traits3_zero_76(void)
 {
   return (KRML_CLITERAL(uint64_t_x2){ .fst = 0ULL, .snd = 0ULL });
 }

--- a/out/test-traits3/traits3.h
+++ b/out/test-traits3/traits3.h
@@ -23,9 +23,9 @@ typedef struct uint64_t_x2_s
 uint64_t_x2;
 
 /**
-This function found in impl {(traits3::internal::KeccakItem<2: usize> for (u64, u64))#1}
+This function found in impl {traits3::internal::KeccakItem<2: usize> for (u64, u64)}
 */
-uint64_t_x2 traits3_zero_f1(void);
+uint64_t_x2 traits3_zero_76(void);
 
 /**
 A monomorphic instance of traits3.keccak

--- a/out/test-where_clauses_closures/where_clauses_closures.c
+++ b/out/test-where_clauses_closures/where_clauses_closures.c
@@ -8,50 +8,50 @@
 #include "where_clauses_closures.h"
 
 /**
-This function found in impl {(where_clauses_closures::Ops<1: usize> for usize)}
+This function found in impl {where_clauses_closures::Ops<1: usize> for usize}
 */
-size_t where_clauses_closures_zero_d6(void)
+size_t where_clauses_closures_zero_af(void)
 {
   return (size_t)0U;
 }
 
 /**
-This function found in impl {(where_clauses_closures::Ops<1: usize> for usize)}
+This function found in impl {where_clauses_closures::Ops<1: usize> for usize}
 */
-size_t where_clauses_closures_of_usize_d6(size_t x)
+size_t where_clauses_closures_of_usize_af(size_t x)
 {
   return x;
 }
 
 /**
-This function found in impl {(core::ops::function::FnMut<(usize), T> for where_clauses_closures::test::closure<T, K>[TraitClause@0, TraitClause@1, TraitClause@2])}
+This function found in impl {core::ops::function::FnMut<(usize), T> for where_clauses_closures::test::closure<T, K>[TraitClause@0, TraitClause@1, TraitClause@2]}
 */
 /**
-A monomorphic instance of where_clauses_closures.test.call_mut_c3
+A monomorphic instance of where_clauses_closures.test.call_mut_1a
 with types size_t
 with const generics
 - K= 1
 */
-size_t where_clauses_closures_test_call_mut_c3_e3(void **_, size_t tupled_args)
+size_t where_clauses_closures_test_call_mut_1a_e3(void **_, size_t tupled_args)
 {
   size_t i = tupled_args;
-  return where_clauses_closures_of_usize_d6(i);
+  return where_clauses_closures_of_usize_af(i);
 }
 
 /**
-This function found in impl {(core::ops::function::FnOnce<(usize), T> for where_clauses_closures::test::closure<T, K>[TraitClause@0, TraitClause@1, TraitClause@2])}
+This function found in impl {core::ops::function::FnOnce<(usize), T> for where_clauses_closures::test::closure<T, K>[TraitClause@0, TraitClause@1, TraitClause@2]}
 */
 /**
-A monomorphic instance of where_clauses_closures.test.call_once_ef
+A monomorphic instance of where_clauses_closures.test.call_once_79
 with types size_t
 with const generics
 - K= 1
 */
-size_t where_clauses_closures_test_call_once_ef_e3(size_t _)
+size_t where_clauses_closures_test_call_once_79_e3(size_t _)
 {
   /* original Rust expression is not an lvalue in C */
   void *lvalue = (void *)0U;
-  return where_clauses_closures_test_call_mut_c3_e3(&lvalue, _);
+  return where_clauses_closures_test_call_mut_1a_e3(&lvalue, _);
 }
 
 /**
@@ -66,9 +66,9 @@ size_t_x2 where_clauses_closures_test_e3(void)
   {
     /* original Rust expression is not an lvalue in C */
     void *lvalue = (void *)0U;
-    x[0U] = where_clauses_closures_test_call_mut_c3_e3(&lvalue, (size_t)0U);
+    x[0U] = where_clauses_closures_test_call_mut_1a_e3(&lvalue, (size_t)0U);
   }
-  size_t y = where_clauses_closures_zero_d6();
+  size_t y = where_clauses_closures_zero_af();
   size_t_x2 lit;
   lit.fst = x[0U];
   lit.snd = y;

--- a/out/test-where_clauses_closures/where_clauses_closures.h
+++ b/out/test-where_clauses_closures/where_clauses_closures.h
@@ -15,7 +15,7 @@
 extern "C" {
 #endif
 
-extern size_t core_clone_impls___core__clone__Clone_for_usize__5__clone(size_t *x0);
+extern size_t core_clone_impls__core__clone__Clone_for_usize__clone(size_t *x0);
 
 #define core_panicking_AssertKind_Eq 0
 #define core_panicking_AssertKind_Ne 1
@@ -24,36 +24,36 @@ extern size_t core_clone_impls___core__clone__Clone_for_usize__5__clone(size_t *
 typedef uint8_t core_panicking_AssertKind;
 
 /**
-This function found in impl {(where_clauses_closures::Ops<1: usize> for usize)}
+This function found in impl {where_clauses_closures::Ops<1: usize> for usize}
 */
-size_t where_clauses_closures_zero_d6(void);
+size_t where_clauses_closures_zero_af(void);
 
 /**
-This function found in impl {(where_clauses_closures::Ops<1: usize> for usize)}
+This function found in impl {where_clauses_closures::Ops<1: usize> for usize}
 */
-size_t where_clauses_closures_of_usize_d6(size_t x);
+size_t where_clauses_closures_of_usize_af(size_t x);
 
 /**
-This function found in impl {(core::ops::function::FnMut<(usize), T> for where_clauses_closures::test::closure<T, K>[TraitClause@0, TraitClause@1, TraitClause@2])}
+This function found in impl {core::ops::function::FnMut<(usize), T> for where_clauses_closures::test::closure<T, K>[TraitClause@0, TraitClause@1, TraitClause@2]}
 */
 /**
-A monomorphic instance of where_clauses_closures.test.call_mut_c3
+A monomorphic instance of where_clauses_closures.test.call_mut_1a
 with types size_t
 with const generics
 - K= 1
 */
-size_t where_clauses_closures_test_call_mut_c3_e3(void **_, size_t tupled_args);
+size_t where_clauses_closures_test_call_mut_1a_e3(void **_, size_t tupled_args);
 
 /**
-This function found in impl {(core::ops::function::FnOnce<(usize), T> for where_clauses_closures::test::closure<T, K>[TraitClause@0, TraitClause@1, TraitClause@2])}
+This function found in impl {core::ops::function::FnOnce<(usize), T> for where_clauses_closures::test::closure<T, K>[TraitClause@0, TraitClause@1, TraitClause@2]}
 */
 /**
-A monomorphic instance of where_clauses_closures.test.call_once_ef
+A monomorphic instance of where_clauses_closures.test.call_once_79
 with types size_t
 with const generics
 - K= 1
 */
-size_t where_clauses_closures_test_call_once_ef_e3(size_t _);
+size_t where_clauses_closures_test_call_once_79_e3(size_t _);
 
 typedef struct size_t_x2_s
 {

--- a/out/test-where_clauses_fncg/where_clauses_fncg.c
+++ b/out/test-where_clauses_fncg/where_clauses_fncg.c
@@ -8,15 +8,15 @@
 #include "where_clauses_fncg.h"
 
 /**
-This function found in impl {(where_clauses_fncg::Foo<K> for u64)}
+This function found in impl {where_clauses_fncg::Foo<K> for u64}
 */
 /**
-A monomorphic instance of where_clauses_fncg.bar_ea
+A monomorphic instance of where_clauses_fncg.bar_16
 with const generics
 - K= 8
 - L= 4
 */
-uint64_t where_clauses_fncg_bar_ea_7b(uint8_t x[8U][4U], uint8_t _[4U][8U])
+uint64_t where_clauses_fncg_bar_16_7b(uint8_t x[8U][4U], uint8_t _[4U][8U])
 {
   return (uint64_t)x[0U][0U];
 }
@@ -33,37 +33,37 @@ uint64_t where_clauses_fncg_f_43(void)
 {
   uint8_t buf[8U][4U] = { { 0U } };
   uint8_t repeat_expression[4U][8U] = { { 0U } };
-  return where_clauses_fncg_bar_ea_7b(buf, repeat_expression);
+  return where_clauses_fncg_bar_16_7b(buf, repeat_expression);
 }
 
 /**
-This function found in impl {(where_clauses_fncg::Foo<K> for u64)}
+This function found in impl {where_clauses_fncg::Foo<K> for u64}
 */
 /**
-A monomorphic instance of where_clauses_fncg.bar_ea
+A monomorphic instance of where_clauses_fncg.bar_16
 with const generics
 - K= 12
 - L= 4
 */
-uint64_t where_clauses_fncg_bar_ea_fa(uint8_t x[12U][4U], uint8_t _[4U][12U])
+uint64_t where_clauses_fncg_bar_16_fa(uint8_t x[12U][4U], uint8_t _[4U][12U])
 {
   return (uint64_t)x[0U][0U];
 }
 
 /**
-This function found in impl {(where_clauses_fncg::UseFoo for ())#1}
+This function found in impl {where_clauses_fncg::UseFoo for ()}
 */
 /**
-A monomorphic instance of where_clauses_fncg.method_foo_eb
+A monomorphic instance of where_clauses_fncg.method_foo_db
 with types uint64_t
 with const generics
 - K= 12
 */
-uint64_t where_clauses_fncg_method_foo_eb_7c(void)
+uint64_t where_clauses_fncg_method_foo_db_7c(void)
 {
   uint8_t buf[12U][4U] = { { 0U } };
   uint8_t repeat_expression[4U][12U] = { { 0U } };
-  return where_clauses_fncg_bar_ea_fa(buf, repeat_expression);
+  return where_clauses_fncg_bar_16_fa(buf, repeat_expression);
 }
 
 /**
@@ -72,9 +72,9 @@ with types ()
 with const generics
 
 */
-uint64_t where_clauses_fncg_g_35(void)
+uint64_t where_clauses_fncg_g_ec(void)
 {
-  return where_clauses_fncg_method_foo_eb_7c();
+  return where_clauses_fncg_method_foo_db_7c();
 }
 
 typedef struct _uint64_t__x2_s
@@ -93,7 +93,7 @@ void where_clauses_fncg_main(void)
   uint64_t *left_val0 = uu____0.fst;
   uint64_t *right_val0 = uu____0.snd;
   EURYDICE_ASSERT(left_val0[0U] == right_val0[0U], "panic!");
-  uint64_t r0 = where_clauses_fncg_g_35();
+  uint64_t r0 = where_clauses_fncg_g_ec();
   /* original Rust expression is not an lvalue in C */
   uint64_t lvalue = 0ULL;
   _uint64_t__x2 uu____1 = { .fst = &r0, .snd = &lvalue };

--- a/out/test-where_clauses_fncg/where_clauses_fncg.h
+++ b/out/test-where_clauses_fncg/where_clauses_fncg.h
@@ -15,8 +15,7 @@
 extern "C" {
 #endif
 
-static inline uint64_t
-core_convert_num___core__convert__From_u8__for_u64__66__from(uint8_t x0);
+static inline uint64_t core_convert_num__core__convert__From_u8__for_u64__from(uint8_t x0);
 
 #define core_panicking_AssertKind_Eq 0
 #define core_panicking_AssertKind_Ne 1
@@ -25,15 +24,15 @@ core_convert_num___core__convert__From_u8__for_u64__66__from(uint8_t x0);
 typedef uint8_t core_panicking_AssertKind;
 
 /**
-This function found in impl {(where_clauses_fncg::Foo<K> for u64)}
+This function found in impl {where_clauses_fncg::Foo<K> for u64}
 */
 /**
-A monomorphic instance of where_clauses_fncg.bar_ea
+A monomorphic instance of where_clauses_fncg.bar_16
 with const generics
 - K= 8
 - L= 4
 */
-uint64_t where_clauses_fncg_bar_ea_7b(uint8_t x[8U][4U], uint8_t _[4U][8U]);
+uint64_t where_clauses_fncg_bar_16_7b(uint8_t x[8U][4U], uint8_t _[4U][8U]);
 
 /**
 A monomorphic instance of where_clauses_fncg.f
@@ -46,26 +45,26 @@ with const generics
 uint64_t where_clauses_fncg_f_43(void);
 
 /**
-This function found in impl {(where_clauses_fncg::Foo<K> for u64)}
+This function found in impl {where_clauses_fncg::Foo<K> for u64}
 */
 /**
-A monomorphic instance of where_clauses_fncg.bar_ea
+A monomorphic instance of where_clauses_fncg.bar_16
 with const generics
 - K= 12
 - L= 4
 */
-uint64_t where_clauses_fncg_bar_ea_fa(uint8_t x[12U][4U], uint8_t _[4U][12U]);
+uint64_t where_clauses_fncg_bar_16_fa(uint8_t x[12U][4U], uint8_t _[4U][12U]);
 
 /**
-This function found in impl {(where_clauses_fncg::UseFoo for ())#1}
+This function found in impl {where_clauses_fncg::UseFoo for ()}
 */
 /**
-A monomorphic instance of where_clauses_fncg.method_foo_eb
+A monomorphic instance of where_clauses_fncg.method_foo_db
 with types uint64_t
 with const generics
 - K= 12
 */
-uint64_t where_clauses_fncg_method_foo_eb_7c(void);
+uint64_t where_clauses_fncg_method_foo_db_7c(void);
 
 /**
 A monomorphic instance of where_clauses_fncg.g
@@ -73,7 +72,7 @@ with types ()
 with const generics
 
 */
-uint64_t where_clauses_fncg_g_35(void);
+uint64_t where_clauses_fncg_g_ec(void);
 
 void where_clauses_fncg_main(void);
 

--- a/out/test-where_clauses_simple/where_clauses_simple.c
+++ b/out/test-where_clauses_simple/where_clauses_simple.c
@@ -8,27 +8,27 @@
 #include "where_clauses_simple.h"
 
 /**
-This function found in impl {(where_clauses_simple::Ops<K> for usize)#1}
+This function found in impl {where_clauses_simple::Ops<K> for usize}
 */
 /**
-A monomorphic instance of where_clauses_simple.of_u16_56
+A monomorphic instance of where_clauses_simple.of_u16_81
 with const generics
 - K= 3
 */
-size_t where_clauses_simple_of_u16_56_e0(uint16_t x)
+size_t where_clauses_simple_of_u16_81_e0(uint16_t x)
 {
   return (size_t)x;
 }
 
 /**
-This function found in impl {(where_clauses_simple::Ops<K> for usize)#1}
+This function found in impl {where_clauses_simple::Ops<K> for usize}
 */
 /**
-A monomorphic instance of where_clauses_simple.add_56
+A monomorphic instance of where_clauses_simple.add_81
 with const generics
 - K= 3
 */
-size_t where_clauses_simple_add_56_e0(uint16_t x[3U], size_t y)
+size_t where_clauses_simple_add_81_e0(uint16_t x[3U], size_t y)
 {
   return (size_t)x[0U] + y + (size_t)3U;
 }
@@ -41,9 +41,9 @@ with const generics
 */
 size_t where_clauses_simple_fn_k_71(void)
 {
-  size_t x = where_clauses_simple_of_u16_56_e0(0U);
+  size_t x = where_clauses_simple_of_u16_81_e0(0U);
   uint16_t repeat_expression[3U] = { 0U };
-  return where_clauses_simple_add_56_e0(repeat_expression, x);
+  return where_clauses_simple_add_81_e0(repeat_expression, x);
 }
 
 typedef struct _size_t__x2_s
@@ -64,17 +64,17 @@ void where_clauses_simple_k_calls_k(void)
 }
 
 /**
-This function found in impl {(where_clauses_simple::Ops<1: usize> for u64)}
+This function found in impl {where_clauses_simple::Ops<1: usize> for u64}
 */
-uint64_t where_clauses_simple_add_d9(uint16_t x[1U], uint64_t y)
+uint64_t where_clauses_simple_add_8e(uint16_t x[1U], uint64_t y)
 {
   return (uint64_t)x[0U] + y;
 }
 
 /**
-This function found in impl {(where_clauses_simple::Ops<1: usize> for u64)}
+This function found in impl {where_clauses_simple::Ops<1: usize> for u64}
 */
-uint64_t where_clauses_simple_of_u16_d9(uint16_t x)
+uint64_t where_clauses_simple_of_u16_8e(uint16_t x)
 {
   return (uint64_t)x;
 }
@@ -87,9 +87,9 @@ with const generics
 */
 uint64_t where_clauses_simple_fn_k_3a(void)
 {
-  uint64_t x = where_clauses_simple_of_u16_d9(0U);
+  uint64_t x = where_clauses_simple_of_u16_8e(0U);
   uint16_t repeat_expression[1U] = { 0U };
-  return where_clauses_simple_add_d9(repeat_expression, x);
+  return where_clauses_simple_add_8e(repeat_expression, x);
 }
 
 typedef struct _uint64_t__x2_s
@@ -110,27 +110,27 @@ void where_clauses_simple_k_calls_one(void)
 }
 
 /**
-This function found in impl {(where_clauses_simple::Ops<K> for usize)#1}
+This function found in impl {where_clauses_simple::Ops<K> for usize}
 */
 /**
-A monomorphic instance of where_clauses_simple.of_u16_56
+A monomorphic instance of where_clauses_simple.of_u16_81
 with const generics
 - K= 1
 */
-size_t where_clauses_simple_of_u16_56_74(uint16_t x)
+size_t where_clauses_simple_of_u16_81_74(uint16_t x)
 {
   return (size_t)x;
 }
 
 /**
-This function found in impl {(where_clauses_simple::Ops<K> for usize)#1}
+This function found in impl {where_clauses_simple::Ops<K> for usize}
 */
 /**
-A monomorphic instance of where_clauses_simple.add_56
+A monomorphic instance of where_clauses_simple.add_81
 with const generics
 - K= 1
 */
-size_t where_clauses_simple_add_56_74(uint16_t x[1U], size_t y)
+size_t where_clauses_simple_add_81_74(uint16_t x[1U], size_t y)
 {
   return (size_t)x[0U] + y + (size_t)1U;
 }
@@ -143,9 +143,9 @@ with const generics
 */
 size_t where_clauses_simple_fn_1_e6(void)
 {
-  size_t x = where_clauses_simple_of_u16_56_74(0U);
+  size_t x = where_clauses_simple_of_u16_81_74(0U);
   uint16_t repeat_expression[1U] = { 0U };
-  return where_clauses_simple_add_56_74(repeat_expression, x);
+  return where_clauses_simple_add_81_74(repeat_expression, x);
 }
 
 void where_clauses_simple_one_calls_k(void)
@@ -164,16 +164,16 @@ with types uint64_t
 with const generics
 
 */
-uint64_t where_clauses_simple_fn_1_6f(void)
+uint64_t where_clauses_simple_fn_1_54(void)
 {
-  uint64_t x = where_clauses_simple_of_u16_d9(0U);
+  uint64_t x = where_clauses_simple_of_u16_8e(0U);
   uint16_t repeat_expression[1U] = { 0U };
-  return where_clauses_simple_add_d9(repeat_expression, x);
+  return where_clauses_simple_add_8e(repeat_expression, x);
 }
 
 void where_clauses_simple_one_calls_one(void)
 {
-  uint64_t r = where_clauses_simple_fn_1_6f();
+  uint64_t r = where_clauses_simple_fn_1_54();
   uint64_t r_expected = 0ULL;
   _uint64_t__x2 uu____0 = { .fst = &r, .snd = &r_expected };
   uint64_t *left_val = uu____0.fst;
@@ -187,13 +187,13 @@ with types uint64_t, size_t
 with const generics
 
 */
-tuple_65 where_clauses_simple_double_47(uint64_t x, size_t y)
+tuple_65 where_clauses_simple_double_21(uint64_t x, size_t y)
 {
   tuple_65 lit;
   uint16_t repeat_expression[1U] = { 0U };
-  lit.fst = where_clauses_simple_add_d9(repeat_expression, x);
+  lit.fst = where_clauses_simple_add_8e(repeat_expression, x);
   uint16_t repeat_expression0[1U] = { 0U };
-  lit.snd = where_clauses_simple_add_56_74(repeat_expression0, y);
+  lit.snd = where_clauses_simple_add_81_74(repeat_expression0, y);
   return lit;
 }
 
@@ -207,9 +207,9 @@ tuple_b6 where_clauses_simple_double_k_7b(size_t x, uint64_t y)
 {
   tuple_b6 lit;
   uint16_t repeat_expression[3U] = { 0U };
-  lit.fst = where_clauses_simple_add_56_e0(repeat_expression, x);
+  lit.fst = where_clauses_simple_add_81_e0(repeat_expression, x);
   uint16_t repeat_expression0[1U] = { 0U };
-  lit.snd = where_clauses_simple_add_d9(repeat_expression0, y);
+  lit.snd = where_clauses_simple_add_8e(repeat_expression0, y);
   return lit;
 }
 
@@ -219,7 +219,7 @@ void where_clauses_simple_main(void)
   where_clauses_simple_k_calls_one();
   where_clauses_simple_one_calls_k();
   where_clauses_simple_one_calls_one();
-  tuple_65 x = where_clauses_simple_double_47(1ULL, (size_t)1U);
+  tuple_65 x = where_clauses_simple_double_21(1ULL, (size_t)1U);
   tuple_b6 y = where_clauses_simple_double_k_7b((size_t)1U, 1ULL);
   uint64_t x_0 = 1ULL;
   size_t x_1 = (size_t)2U;

--- a/out/test-where_clauses_simple/where_clauses_simple.h
+++ b/out/test-where_clauses_simple/where_clauses_simple.h
@@ -15,15 +15,13 @@
 extern "C" {
 #endif
 
-extern uint64_t core_clone_impls___core__clone__Clone_for_u64__9__clone(uint64_t *x0);
+extern uint64_t core_clone_impls__core__clone__Clone_for_u64__clone(uint64_t *x0);
 
-extern size_t core_clone_impls___core__clone__Clone_for_usize__5__clone(size_t *x0);
+extern size_t core_clone_impls__core__clone__Clone_for_usize__clone(size_t *x0);
 
-static inline uint64_t
-core_convert_num___core__convert__From_u16__for_u64__70__from(uint16_t x0);
+static inline uint64_t core_convert_num__core__convert__From_u16__for_u64__from(uint16_t x0);
 
-static inline size_t
-core_convert_num___core__convert__From_u16__for_usize__96__from(uint16_t x0);
+static inline size_t core_convert_num__core__convert__From_u16__for_usize__from(uint16_t x0);
 
 #define core_panicking_AssertKind_Eq 0
 #define core_panicking_AssertKind_Ne 1
@@ -32,24 +30,24 @@ core_convert_num___core__convert__From_u16__for_usize__96__from(uint16_t x0);
 typedef uint8_t core_panicking_AssertKind;
 
 /**
-This function found in impl {(where_clauses_simple::Ops<K> for usize)#1}
+This function found in impl {where_clauses_simple::Ops<K> for usize}
 */
 /**
-A monomorphic instance of where_clauses_simple.of_u16_56
+A monomorphic instance of where_clauses_simple.of_u16_81
 with const generics
 - K= 3
 */
-size_t where_clauses_simple_of_u16_56_e0(uint16_t x);
+size_t where_clauses_simple_of_u16_81_e0(uint16_t x);
 
 /**
-This function found in impl {(where_clauses_simple::Ops<K> for usize)#1}
+This function found in impl {where_clauses_simple::Ops<K> for usize}
 */
 /**
-A monomorphic instance of where_clauses_simple.add_56
+A monomorphic instance of where_clauses_simple.add_81
 with const generics
 - K= 3
 */
-size_t where_clauses_simple_add_56_e0(uint16_t x[3U], size_t y);
+size_t where_clauses_simple_add_81_e0(uint16_t x[3U], size_t y);
 
 /**
 A monomorphic instance of where_clauses_simple.fn_k
@@ -62,14 +60,14 @@ size_t where_clauses_simple_fn_k_71(void);
 void where_clauses_simple_k_calls_k(void);
 
 /**
-This function found in impl {(where_clauses_simple::Ops<1: usize> for u64)}
+This function found in impl {where_clauses_simple::Ops<1: usize> for u64}
 */
-uint64_t where_clauses_simple_add_d9(uint16_t x[1U], uint64_t y);
+uint64_t where_clauses_simple_add_8e(uint16_t x[1U], uint64_t y);
 
 /**
-This function found in impl {(where_clauses_simple::Ops<1: usize> for u64)}
+This function found in impl {where_clauses_simple::Ops<1: usize> for u64}
 */
-uint64_t where_clauses_simple_of_u16_d9(uint16_t x);
+uint64_t where_clauses_simple_of_u16_8e(uint16_t x);
 
 /**
 A monomorphic instance of where_clauses_simple.fn_k
@@ -82,24 +80,24 @@ uint64_t where_clauses_simple_fn_k_3a(void);
 void where_clauses_simple_k_calls_one(void);
 
 /**
-This function found in impl {(where_clauses_simple::Ops<K> for usize)#1}
+This function found in impl {where_clauses_simple::Ops<K> for usize}
 */
 /**
-A monomorphic instance of where_clauses_simple.of_u16_56
+A monomorphic instance of where_clauses_simple.of_u16_81
 with const generics
 - K= 1
 */
-size_t where_clauses_simple_of_u16_56_74(uint16_t x);
+size_t where_clauses_simple_of_u16_81_74(uint16_t x);
 
 /**
-This function found in impl {(where_clauses_simple::Ops<K> for usize)#1}
+This function found in impl {where_clauses_simple::Ops<K> for usize}
 */
 /**
-A monomorphic instance of where_clauses_simple.add_56
+A monomorphic instance of where_clauses_simple.add_81
 with const generics
 - K= 1
 */
-size_t where_clauses_simple_add_56_74(uint16_t x[1U], size_t y);
+size_t where_clauses_simple_add_81_74(uint16_t x[1U], size_t y);
 
 /**
 A monomorphic instance of where_clauses_simple.fn_1
@@ -117,7 +115,7 @@ with types uint64_t
 with const generics
 
 */
-uint64_t where_clauses_simple_fn_1_6f(void);
+uint64_t where_clauses_simple_fn_1_54(void);
 
 void where_clauses_simple_one_calls_one(void);
 
@@ -139,7 +137,7 @@ with types uint64_t, size_t
 with const generics
 
 */
-tuple_65 where_clauses_simple_double_47(uint64_t x, size_t y);
+tuple_65 where_clauses_simple_double_21(uint64_t x, size_t y);
 
 /**
 A monomorphic instance of K.

--- a/test/partial_eq_stubs.c
+++ b/test/partial_eq_stubs.c
@@ -1,6 +1,6 @@
 #include "partial_eq.h"
 
 extern core_result_Result_10
-core_fmt__core__fmt__Formatter__a__11__write_str(core_fmt_Formatter *x0, Eurydice_str x1) {
+core_fmt__core__fmt__Formatter__a___write_str(core_fmt_Formatter *x0, Eurydice_str x1) {
   return core_result_Ok;
 }


### PR DESCRIPTION
They were the main source of name instability when updating rustc versions. Turns out they're entirely unnecessary for our purposes: the name of types is enough.