### PR TITLE
Two changes pending libcrux fixes

### DIFF
--- a/lib/AstOfLlbc.ml
+++ b/lib/AstOfLlbc.ml
@@ -2573,10 +2573,6 @@ let known_failures =
 
 let replacements = List.map (fun (p, d) -> Charon.NameMatcher.parse_pattern p, d) [
   "core::result::{core::result::Result<@T, @E>}::unwrap", Builtin.unwrap;
-  (* FIXME: remove the line below once libcrux passes --include 'core::num::*::BITS'
-     --include 'core::num::*::MAX' to charon, AND does a single invocation of charon (instead of
-     three currently) *)
-  "core::num::{u32}::BITS", (fun lid -> Krml.Ast.DGlobal ([], lid, 0, Krml.Helpers.uint32, Krml.Helpers.mk_uint32 32));
 ]
 
 (* Catch-all error handler (last resort) *)
@@ -2629,8 +2625,7 @@ let file_of_crate (crate : Charon.LlbcAst.crate) : Krml.Ast.file =
   } =
     crate
   in
-  (* FIXME once libcrux passes --preset=eurydice to charon *)
-  if options.remove_associated_types <> [ "*" ] then begin
+  if options.preset <> Some Eurydice then begin
     Printf.eprintf "ERROR: Eurydice expects Charon to be invoked with `--preset=eurydice`\n";
     exit 255
   end;


### PR DESCRIPTION
To be merged once upstream libcrux changes its c.sh script to do something like:

```
     RUSTFLAGS="--cfg eurydice" $CHARON_HOME/bin/charon --preset eurydice --include secrets --include sha3 --rustc-arg=-Cdebug-assertions=no \
      --include 'core::num::*::BITS' --include 'core::num::*::MAX' \
       --include 'libcrux::secrets::*' \
       $features
```

note that the include libcrux::secrets option remains to be determined -- I don't know the exact syntax yet