### PR TITLE
Improve handling of names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,10 @@ test/issue_105.llbc: CHARON_EXTRA = \
 
 test/array2d.llbc: CHARON_EXTRA = --include=core::array::equality::*
 
+test/println.llbc: CHARON_EXTRA = \
+  --include=core::fmt::Arguments --include=core::fmt::rt::*::new_const \
+  --include=core::fmt::rt::Argument
+
 test-partial_eq: EXTRA_C = ../../test/partial_eq_stubs.c
 test-nested_arrays: EXTRA = -funroll-loops 0
 test-array: EXTRA = -fcomments

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -301,7 +301,7 @@ Supported options:|}
   let files = Eurydice.Cleanup2.float_comments files in
   Eurydice.Logging.log "Phase2.95" "%a" pfiles files;
   let files = Eurydice.Cleanup2.bonus_cleanups#visit_files [] files in
-  (* Macros stemming from globals *)
+  (* Macros stemming from globals -- FIXME why is this not Krml.AstToCStar.mk_macros_set? *)
   let files, macros = Eurydice.Cleanup2.build_macros files in
 
   Eurydice.Logging.log "Phase3" "%a" pfiles files;
@@ -314,10 +314,6 @@ Supported options:|}
   let files = Eurydice.Cleanup3.decay_cg_externals#visit_files (scope_env, false) files in
   let files = Eurydice.Cleanup3.add_extra_type_to_slice_index#visit_files () files in
   Eurydice.Logging.log "Phase3.1" "%a" pfiles files;
-  let macros =
-    let cg_macros = Eurydice.Cleanup3.build_cg_macros#visit_files () files in
-    Krml.Idents.LidSet.(union (union macros cg_macros) Eurydice.Builtin.macros)
-  in
   let c_name_map = Krml.GlobalNames.mapping (fst scope_env) in
 
   let open Krml in

--- a/flake.lock
+++ b/flake.lock
@@ -93,11 +93,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1753450483,
-        "narHash": "sha256-PLthm6CCqDMGUySypNX/W/Q5rgIjPrdA8vknN/IgTEs=",
+        "lastModified": 1753722860,
+        "narHash": "sha256-8HV2RSl01Rey+g59jX3nYpkqcavQWHrt6jxAzXoRO/o=",
         "owner": "fstarlang",
         "repo": "fstar",
-        "rev": "e80f92b8ef8492858849f291842d5e4ec0e0d889",
+        "rev": "bfab528fad21396ae7b2cab926e0651a3944e6ee",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753382924,
-        "narHash": "sha256-grdaj39GVz1vctvxgq9/HUQ+a1uVnm0Lgb5vieY/qLI=",
+        "lastModified": 1753811924,
+        "narHash": "sha256-nJbZCrpIfd2l43arCHZZnBZOGwr58mTnxwg7ARqmZNs=",
         "owner": "FStarLang",
         "repo": "karamel",
-        "rev": "a0b4dabb385bb3c5a43ec8735354acd9e33ed8c9",
+        "rev": "cf6cace695a303444e09d9986372aa988366b73d",
         "type": "github"
       },
       "original": {

--- a/lib/Builtin.ml
+++ b/lib/Builtin.ml
@@ -17,7 +17,6 @@ let mk_range_from (t : K.typ) : K.typ = K.TApp (range_from, [ t ])
 let option : K.lident = [ "core"; "option" ], "Option"
 let mk_option (t : K.typ) : K.typ = K.TApp (option, [ t ])
 let array_copy = [ "Eurydice" ], "array_copy"
-let macros = Krml.Idents.LidSet.of_list []
 
 (* Things that could otherwise be emitted as an extern prototype, but for some
    reason ought to be skipped. *)

--- a/lib/Cleanup3.ml
+++ b/lib/Cleanup3.ml
@@ -61,10 +61,10 @@ let decay_cg_externals =
 
           (* We're good. Find the allocated C name for our declaration, and allocate a new C name for
              the extra declaration *)
-          let c_name = Option.get (GlobalNames.lookup (fst scope_env) name) in
+          let c_name = Option.get (GlobalNames.lookup (fst scope_env) (name, Other)) in
           let new_name = fst name, snd name ^ "_" in
           self#record scope_env ~is_type:false ~is_external:true flags new_name;
-          let new_c_name = Option.get (GlobalNames.lookup (fst scope_env) new_name) in
+          let new_c_name = Option.get (GlobalNames.lookup (fst scope_env) (new_name, Other)) in
 
           (* We build: #define <<c_name>>(x0, ..., xn, _ret_t) \
              <<new_c_name>>(x0, ..., xn) *)
@@ -165,9 +165,9 @@ let also_skip_prefix_for_external_types (scope_env, _) =
     inherit [_] iter as _super
 
     method! visit_TQualified () lid =
-      if GlobalNames.lookup scope_env lid = None && GlobalNames.skip_prefix lid then
+      if GlobalNames.lookup scope_env (lid, Type) = None && GlobalNames.skip_prefix lid then
         let target = GlobalNames.target_c_name ~attempt_shortening:true ~kind:Type lid in
-        let actual = GlobalNames.extend scope_env scope_env false lid target in
+        let actual = GlobalNames.extend scope_env scope_env false (lid, Type) target in
         if actual <> fst target then
           KPrint.bprintf "Warning! The skip_prefix options generate name conflicts\n"
   end

--- a/out/test-closure_fn_cast/closure_fn_cast.c
+++ b/out/test-closure_fn_cast/closure_fn_cast.c
@@ -44,6 +44,6 @@ int32_t closure_fn_cast_main_closure_as_fn(int32_t arg1)
 void closure_fn_cast_main(void)
 {
   int32_t (*f)(int32_t x0) = closure_fn_cast_main_closure_as_fn;
-  LowStar_Ignore_ignore(f((int32_t)1), int32_t, void *);
+  KRML_HOST_IGNORE(f((int32_t)1));
 }
 

--- a/out/test-inline_attributes/inline_attributes.c
+++ b/out/test-inline_attributes/inline_attributes.c
@@ -24,8 +24,8 @@ KRML_MUSTINLINE uint32_t inline_attributes_h(void)
 
 void inline_attributes_main(void)
 {
-  LowStar_Ignore_ignore(inline_attributes_f(), uint32_t, void *);
-  LowStar_Ignore_ignore(inline_attributes_g(), uint32_t, void *);
-  LowStar_Ignore_ignore(inline_attributes_h(), uint32_t, void *);
+  inline_attributes_f();
+  inline_attributes_g();
+  inline_attributes_h();
 }
 

--- a/out/test-more_primitive_types/more_primitive_types.c
+++ b/out/test-more_primitive_types/more_primitive_types.c
@@ -114,8 +114,8 @@ void more_primitive_types_use_more_primitive_types(void)
       .uint128 = Eurydice_Int128_u128_from_bits(0xffffffffffffULL, 0xffffffffffffffffULL),
       .c = 97U
     };
-  LowStar_Ignore_ignore(more_primitive_types_match_u128(&p), int32_t, void *);
-  LowStar_Ignore_ignore(more_primitive_types_match_i128(&p), int32_t, void *);
+  more_primitive_types_match_u128(&p);
+  more_primitive_types_match_i128(&p);
   EURYDICE_ASSERT(p.c == (uint32_t)s[0U], "panic!");
 }
 

--- a/out/test-trait_generics/trait_generics.c
+++ b/out/test-trait_generics/trait_generics.c
@@ -28,7 +28,7 @@ with const generics
 */
 void trait_generics_from_fn_3c(void)
 {
-  LowStar_Ignore_ignore(trait_generics_call_once_a3_95(), uint32_t, void *);
+  trait_generics_call_once_a3_95();
 }
 
 void trait_generics_main(void)

--- a/test/names.rs
+++ b/test/names.rs
@@ -1,0 +1,3 @@
+struct Foo { x: u32, y: u32 }
+enum Baz { Foo(u32, u32), Bar(u32) }
+fn main() {}


### PR DESCRIPTION
While working on #162 it turned out that in core::fmt::rt, there was an enum case name that was conflicting with a type name, which blocked extraction.

This required some upstream work in krml (see fstarlang/karamel#633) and now this makes Eurydice catch up