### PR TITLE
Fix eurydice_glue.h rotate_left

### DIFF
--- a/include/eurydice_glue.h
+++ b/include/eurydice_glue.h
@@ -392,7 +392,7 @@ static inline size_t core_num__usize__wrapping_mul(size_t x, size_t y) {
 }
 
 static inline uint64_t core_num__u64__rotate_left(uint64_t x0, uint32_t x1) {
-  return (x0 << x1 | x0 >> (64 - x1));
+  return (x0 << x1) | (x0 >> ((-x1) & 63));
 }
 
 static inline void core_ops_arith__i32__add_assign(int32_t *x0, int32_t *x1) {


### PR DESCRIPTION
The implementation of `core_num__u64__rotate_left` has undefined behaviour for `x1 = 0`.