### PR TITLE
Remove dependency on fstar for building eurydice

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,6 @@
       karamel = inputs.karamel.packages.${system}.default.override {
         ocamlPackages = pkgs.ocamlPackages;
       };
-      fstar = inputs.karamel.inputs.fstar.packages.${system}.default;
       krml = karamel.passthru.lib;
 
       charon-packages = inputs.charon.packages.${system};
@@ -58,7 +57,7 @@
               tests = clangStdenv.mkDerivation {
                 name = "tests";
                 src = ./.;
-                KRML_HOME = karamel;
+                KRML_HOME = karamel.src;
                 FSTAR_HOME = "dummy";
                 EURYDICE = "${eurydice}/bin/eurydice";
                 buildInputs = [ eurydice ];
@@ -139,7 +138,7 @@
           pkgs.rustup
         ];
         buildInputs = [ charon.buildInputs ];
-        nativeBuildInputs = [ charon.nativeBuildInputs fstar pkgs.clang ];
+        nativeBuildInputs = [ charon.nativeBuildInputs pkgs.clang ];
 
         inputsFrom = [
           self.packages.${system}.default


### PR DESCRIPTION
The nix value for the `KRML_HOME` env var caused us to build the full `karamel` package instead of just its ocaml library. This PR fixes that; we should no longer depend on fstar.