### PR TITLE
simple fix of types of globals

### DIFF
--- a/lib/AstOfLlbc.ml
+++ b/lib/AstOfLlbc.ml
@@ -809,7 +809,7 @@ let rec expression_of_place (env : env) (p : C.place) : K.expr =
       K.(with_type t (EBound i))
   | PlaceGlobal { id; _ } ->
       let global = env.get_nth_global id in
-      K.with_type (typ_of_ty env global.ty) (K.EQualified (lid_of_name env global.item_meta.name))
+      K.with_type (typ_of_ty env p.ty) (K.EQualified (lid_of_name env global.item_meta.name))
   | PlaceProjection (sub_place, PtrMetadata) -> begin
       let e = expression_of_place env sub_place in
       match e.typ with


### PR DESCRIPTION
As mentioned in #310 , here's a fix to the problem mentioned there. But instead of the more complex substitution as in #308 , we simply fix it by using the tagged type of the place.

Notably, in #308 , we will need to fetch the vtable instance pointer, and substitute the generics with the generics args from the reference to generate the correct type ourselves. But in `PlaceGlobal`, we have available type tagged by Charon.

Further, please note that the tagged type may not yield exactly the same result as the substitution -- because of the difference in lifetime parameters.

As mentioned in #310 , there might be more hidden bugs like this.