### PR TITLE
Change the representation of str to be able to compile more transmute casts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,9 @@ out/test-%/main.c: test/main.c
 	mkdir -p out/test-$*
 	sed 's/__NAME__/$*/g' $< > $@
 
+test/substr.llbc: CHARON_EXTRA = \
+  --include=core::str::traits::*
+
 test/issue_99.llbc: CHARON_EXTRA = \
   --include=core::option::*::as_ref
 
@@ -86,6 +89,7 @@ test/println.llbc: CHARON_EXTRA = \
 test/option.llbc: CHARON_EXTRA = \
   --include=core::option::*
 
+test-substr: EXTRA = --keep-going
 test-partial_eq: EXTRA_C = ../../test/partial_eq_stubs.c
 test-nested_arrays: EXTRA = -funroll-loops 0
 test-array: EXTRA = -fcomments

--- a/lib/AstOfLlbc.ml
+++ b/lib/AstOfLlbc.ml
@@ -1877,6 +1877,12 @@ let expression_of_rvalue (env : env) (p : C.rvalue) expected_ty : K.expr =
         match ck with
         (* Here are `literal_type`s *)
         | C.CastScalar (f, t) -> f = t
+        | C.CastTransmute
+            ( TRef (_, TAdt { id = TBuiltin TStr; _ }, _),
+              TRef
+                ( _,
+                  TAdt { id = TBuiltin TSlice; generics = { types = [ TLiteral (TUInt U8) ]; _ } },
+                  _ ) ) -> true
         (* The following are `type`s *)
         | C.CastFnPtr (f, t) | C.CastRawPtr (f, t) | C.CastUnsize (f, t, _) | C.CastTransmute (f, t)
           -> f = t
@@ -1979,6 +1985,7 @@ let expression_of_rvalue (env : env) (p : C.rvalue) expected_ty : K.expr =
             in
             K.with_type typ_arr (mk_expr_arr_struct array_expr)
       end
+  | NullaryOp (UbChecks, TLiteral TBool) -> Krml.Helpers.etrue
   | rvalue ->
       failwith
         ("unsupported rvalue: `"

--- a/lib/Builtin.ml
+++ b/lib/Builtin.ml
@@ -427,7 +427,7 @@ let replace =
 let derefed_slice = [ "Eurydice" ], "derefed_slice"
 
 (** The C counterpart of `&str` *)
-let str_t = mk_dst_ref c_char_t (TInt SizeT)
+let str_t = mk_dst_ref (TInt UInt8) (TInt SizeT)
 
 (** The C counterpart of `str` and serves twofold functionalities: (1) when in expressions, it
     serves as a placeholder to get referenced again; (2) when in customised DST definition, it is
@@ -435,7 +435,7 @@ let str_t = mk_dst_ref c_char_t (TInt SizeT)
 let deref_str_t = K.TApp (derefed_slice, [ c_char_t ])
 
 let c_string_def =
-  K.DType (([ "Prims" ], "string"), [ Private ], 0, 0, Abbrev (TBuf (c_char_t, false)))
+  K.DType (([ "Prims" ], "string"), [ Private ], 0, 0, Abbrev (TBuf (TInt UInt8, false)))
 
 (* Take the type of the ptr field *)
 let dst_new ~ptr ~len t =


### PR DESCRIPTION
@ssyram this is a WIP -- I tried to extract more code from the `str` module

I think in the long run, we will want a mechanism to encode some type equations for when things have the same representation, like you have done on your branch -- this is one case where we have to know that str is a slice of u8, and it looks based on your branch that there are more such cases

