### PR TITLE
Another round of cosmetic improvements -- this fixes #270

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,3 +199,6 @@ format-apply:
 .PHONY: clean-llbc
 clean-llbc:
 	rm test/*.llbc || true
+
+debug-ppx-%: lib/%
+	dune describe pp $<

--- a/lib/Cleanup2.ml
+++ b/lib/Cleanup2.ml
@@ -1135,6 +1135,10 @@ let cosmetic =
 
     method! visit_expr _ e =
       match e with
+      | [%cremepat {| core::slice::?impl::len<?>(Eurydice::array_to_slice_shared[#?n]<?>(?)) |}]
+        when impl = "{@Slice<T>}" -> n
+      | [%cremepat {| core::slice::?impl::len<?>(Eurydice::array_to_slice_mut[#?n]<?>(?)) |}]
+        when impl = "{@Slice<T>}" -> n
       | [%cremepat {| core::slice::?impl::len<?>(?e) |}] when impl = "{@Slice<T>}" ->
           with_type (TInt SizeT) (EField (e, "meta"))
       | [%cremepat {| Eurydice::slice_index_mut<?t>(?s, ?i) |}] ->

--- a/out/test-floating_points/floating_points.c
+++ b/out/test-floating_points/floating_points.c
@@ -7,34 +7,6 @@
 
 #include "floating_points.h"
 
-/**
-A monomorphic instance of Eurydice.array_to_slice_shared
-with types float32_t
-with const generics
-- N= 100
-*/
-static Eurydice_dst_ref_shared_0f array_to_slice_shared_de(const Eurydice_arr_d5 *a)
-{
-  Eurydice_dst_ref_shared_0f lit;
-  lit.ptr = a->data;
-  lit.meta = (size_t)100U;
-  return lit;
-}
-
-/**
-A monomorphic instance of Eurydice.array_to_slice_shared
-with types float64_t
-with const generics
-- N= 100
-*/
-static Eurydice_dst_ref_shared_51 array_to_slice_shared_51(const Eurydice_arr_22 *a)
-{
-  Eurydice_dst_ref_shared_51 lit;
-  lit.ptr = a->data;
-  lit.meta = (size_t)100U;
-  return lit;
-}
-
 typedef struct const_float32_t__x2_s
 {
   const float32_t *fst;
@@ -83,13 +55,13 @@ void floating_points_main(void)
   const_float64_t__x2 uu____1 = { .fst = arr2.data, .snd = &lvalue1 };
   EURYDICE_ASSERT(uu____1.fst[0U] == uu____1.snd[0U], "panic!");
   /* original Rust expression is not an lvalue in C */
-  size_t lvalue2 = array_to_slice_shared_de(&arr).meta;
+  size_t lvalue2 = (size_t)100U;
   /* original Rust expression is not an lvalue in C */
   size_t lvalue3 = (size_t)100U;
   const_size_t__x2 uu____2 = { .fst = &lvalue2, .snd = &lvalue3 };
   EURYDICE_ASSERT(uu____2.fst[0U] == uu____2.snd[0U], "panic!");
   /* original Rust expression is not an lvalue in C */
-  size_t lvalue4 = array_to_slice_shared_51(&arr2).meta;
+  size_t lvalue4 = (size_t)100U;
   /* original Rust expression is not an lvalue in C */
   size_t lvalue = (size_t)100U;
   const_size_t__x2 uu____3 = { .fst = &lvalue4, .snd = &lvalue };

--- a/out/test-floating_points/floating_points.h
+++ b/out/test-floating_points/floating_points.h
@@ -22,36 +22,12 @@ extern "C" {
 typedef uint8_t core_panicking_AssertKind;
 
 /**
-A monomorphic instance of Eurydice.dst_ref_shared
-with types float32_t, size_t
-
-*/
-typedef struct Eurydice_dst_ref_shared_0f_s
-{
-  const float32_t *ptr;
-  size_t meta;
-}
-Eurydice_dst_ref_shared_0f;
-
-/**
 A monomorphic instance of Eurydice.arr
 with types float32_t
 with const generics
 - $100size_t
 */
 typedef struct Eurydice_arr_d5_s { float32_t data[100U]; } Eurydice_arr_d5;
-
-/**
-A monomorphic instance of Eurydice.dst_ref_shared
-with types float64_t, size_t
-
-*/
-typedef struct Eurydice_dst_ref_shared_51_s
-{
-  const float64_t *ptr;
-  size_t meta;
-}
-Eurydice_dst_ref_shared_51;
 
 /**
 A monomorphic instance of Eurydice.arr

--- a/out/test-libcrux-no-const/internal/libcrux_core.h
+++ b/out/test-libcrux-no-const/internal/libcrux_core.h
@@ -1179,7 +1179,7 @@ with types uint8_t
 with const generics
 - N= 504
 */
-Eurydice_mut_borrow_slice_u8 Eurydice_array_to_slice_mut_850(Eurydice_arr_b0 *a);
+Eurydice_mut_borrow_slice_u8 Eurydice_array_to_slice_mut_85(Eurydice_arr_b0 *a);
 
 /**
 A monomorphic instance of Eurydice.arr

--- a/out/test-libcrux-no-const/libcrux_core.c
+++ b/out/test-libcrux-no-const/libcrux_core.c
@@ -1618,7 +1618,7 @@ with types uint8_t
 with const generics
 - N= 504
 */
-Eurydice_mut_borrow_slice_u8 Eurydice_array_to_slice_mut_850(Eurydice_arr_b0 *a)
+Eurydice_mut_borrow_slice_u8 Eurydice_array_to_slice_mut_85(Eurydice_arr_b0 *a)
 {
   Eurydice_mut_borrow_slice_u8 lit;
   lit.ptr = a->data;

--- a/out/test-libcrux-no-const/libcrux_mlkem_avx2.c
+++ b/out/test-libcrux-no-const/libcrux_mlkem_avx2.c
@@ -1925,10 +1925,10 @@ shake128_squeeze_first_three_blocks_e0(Eurydice_arr_05 *st)
   Eurydice_arr_b0 out2 = { .data = { 0U } };
   Eurydice_arr_b0 out3 = { .data = { 0U } };
   libcrux_sha3_avx2_x4_incremental_shake128_squeeze_first_three_blocks(st,
-    Eurydice_array_to_slice_mut_850(&out0),
-    Eurydice_array_to_slice_mut_850(&out1),
-    Eurydice_array_to_slice_mut_850(&out2),
-    Eurydice_array_to_slice_mut_850(&out3));
+    Eurydice_array_to_slice_mut_85(&out0),
+    Eurydice_array_to_slice_mut_85(&out1),
+    Eurydice_array_to_slice_mut_85(&out2),
+    Eurydice_array_to_slice_mut_85(&out3));
   out.data[0U] = out0;
   out.data[1U] = out1;
   out.data[2U] = out2;
@@ -2299,32 +2299,6 @@ static KRML_MUSTINLINE Eurydice_arr_9d sample_from_xof_6c1(Eurydice_arr_c3 *seed
 }
 
 /**
-A monomorphic instance of Eurydice.dst_ref_mut
-with types libcrux_ml_kem_polynomial_PolynomialRingElement_f6, size_t
-
-*/
-typedef struct dst_ref_mut_fb_s
-{
-  Eurydice_arr_51 *ptr;
-  size_t meta;
-}
-dst_ref_mut_fb;
-
-/**
-A monomorphic instance of Eurydice.array_to_slice_mut
-with types libcrux_ml_kem_polynomial_PolynomialRingElement libcrux_ml_kem_vector_avx2_SIMD256Vector
-with const generics
-- N= 3
-*/
-static dst_ref_mut_fb array_to_slice_mut_cf3(Eurydice_arr_9d *a)
-{
-  dst_ref_mut_fb lit;
-  lit.ptr = a->data;
-  lit.meta = (size_t)3U;
-  return lit;
-}
-
-/**
 A monomorphic instance of libcrux_ml_kem.matrix.sample_matrix_A
 with types libcrux_ml_kem_vector_avx2_SIMD256Vector, libcrux_ml_kem_hash_functions_avx2_Simd256Hash
 with const generics
@@ -2358,8 +2332,10 @@ sample_matrix_A_6c1(Eurydice_arr_7d *A_transpose, Eurydice_arr_48 *seed, bool tr
       seeds.data[j].data[32U] = (uint8_t)i1;
       seeds.data[j].data[33U] = (uint8_t)j;);
     Eurydice_arr_9d sampled = sample_from_xof_6c1(&seeds);
-    for (size_t i = (size_t)0U; i < array_to_slice_mut_cf3(&sampled).meta; i++)
-    {
+    KRML_MAYBE_FOR3(i,
+      (size_t)0U,
+      (size_t)3U,
+      (size_t)1U,
       size_t j = i;
       Eurydice_arr_51 sample = sampled.data[j];
       if (transpose)
@@ -2369,8 +2345,7 @@ sample_matrix_A_6c1(Eurydice_arr_7d *A_transpose, Eurydice_arr_48 *seed, bool tr
       else
       {
         A_transpose->data[i1].data[j] = sample;
-      }
-    });
+      }););
 }
 
 /**
@@ -2556,8 +2531,10 @@ with const generics
 static KRML_MUSTINLINE void
 serialize_vector_ab(Eurydice_arr_9d *key, Eurydice_mut_borrow_slice_u8 out)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_mut_cf3(key).meta; i++)
-  {
+  KRML_MAYBE_FOR3(i,
+    (size_t)0U,
+    (size_t)3U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_51 re = key->data[i0];
     Eurydice_mut_borrow_slice_u8
@@ -2571,8 +2548,7 @@ serialize_vector_ab(Eurydice_arr_9d *key, Eurydice_mut_borrow_slice_u8 out)
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_arr_cc lvalue = serialize_uncompressed_ring_element_84(&re);
-    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_mut_fe(&lvalue), uint8_t);
-  }
+    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_mut_fe(&lvalue), uint8_t););
 }
 
 /**
@@ -2926,8 +2902,10 @@ sample_matrix_A_b31(Eurydice_arr_7d *A_transpose, Eurydice_arr_48 *seed, bool tr
       seeds.data[j].data[32U] = (uint8_t)i1;
       seeds.data[j].data[33U] = (uint8_t)j;);
     Eurydice_arr_9d sampled = sample_from_xof_b31(&seeds);
-    for (size_t i = (size_t)0U; i < array_to_slice_mut_cf3(&sampled).meta; i++)
-    {
+    KRML_MAYBE_FOR3(i,
+      (size_t)0U,
+      (size_t)3U,
+      (size_t)1U,
       size_t j = i;
       Eurydice_arr_51 sample = sampled.data[j];
       if (transpose)
@@ -2937,8 +2915,7 @@ sample_matrix_A_b31(Eurydice_arr_7d *A_transpose, Eurydice_arr_48 *seed, bool tr
       else
       {
         A_transpose->data[i1].data[j] = sample;
-      }
-    });
+      }););
 }
 
 /**
@@ -3579,32 +3556,6 @@ static Eurydice_arr_51 call_mut_73_221(void **_)
 }
 
 /**
-A monomorphic instance of Eurydice.dst_ref_mut
-with types Eurydice_arr_9d, size_t
-
-*/
-typedef struct dst_ref_mut_c8_s
-{
-  Eurydice_arr_9d *ptr;
-  size_t meta;
-}
-dst_ref_mut_c8;
-
-/**
-A monomorphic instance of Eurydice.array_to_slice_mut
-with types Eurydice_arr libcrux_ml_kem_polynomial_PolynomialRingElement libcrux_ml_kem_vector_avx2_SIMD256Vector[[$3size_t]]
-with const generics
-- N= 3
-*/
-static dst_ref_mut_c8 array_to_slice_mut_b50(Eurydice_arr_7d *a)
-{
-  dst_ref_mut_c8 lit;
-  lit.ptr = a->data;
-  lit.meta = (size_t)3U;
-  return lit;
-}
-
-/**
  Given two `KyberPolynomialRingElement`s in their NTT representations,
  compute their product. Given two polynomials in the NTT domain `f^` and `ĵ`,
  the `iᵗʰ` coefficient of the product `k̂` is determined by the calculation:
@@ -3671,32 +3622,6 @@ ntt_multiply_d6_84(Eurydice_arr_51 *self, Eurydice_arr_51 *rhs)
 }
 
 /**
-A monomorphic instance of Eurydice.dst_ref_mut
-with types libcrux_ml_kem_vector_avx2_SIMD256Vector, size_t
-
-*/
-typedef struct dst_ref_mut_4b_s
-{
-  __m256i *ptr;
-  size_t meta;
-}
-dst_ref_mut_4b;
-
-/**
-A monomorphic instance of Eurydice.array_to_slice_mut
-with types libcrux_ml_kem_vector_avx2_SIMD256Vector
-with const generics
-- N= 16
-*/
-static dst_ref_mut_4b array_to_slice_mut_85(Eurydice_arr_51 *a)
-{
-  dst_ref_mut_4b lit;
-  lit.ptr = a->data;
-  lit.meta = (size_t)16U;
-  return lit;
-}
-
-/**
  Given two polynomial ring elements `lhs` and `rhs`, compute the pointwise
  sum of their constituent coefficients.
 */
@@ -3709,11 +3634,12 @@ with const generics
 static KRML_MUSTINLINE void
 add_to_ring_element_ab(Eurydice_arr_51 *myself, Eurydice_arr_51 *rhs)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_mut_85(myself).meta; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (size_t)0U,
+    (size_t)16U,
+    (size_t)1U,
     size_t i0 = i;
-    myself->data[i0] = libcrux_ml_kem_vector_avx2_add_f5(myself->data[i0], &rhs->data[i0]);
-  }
+    myself->data[i0] = libcrux_ml_kem_vector_avx2_add_f5(myself->data[i0], &rhs->data[i0]););
 }
 
 /**
@@ -3795,21 +3721,23 @@ compute_As_plus_e_ab(
   Eurydice_arr_9d *error_as_ntt
 )
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_mut_b50(matrix_A).meta; i++)
-  {
+  KRML_MAYBE_FOR3(i,
+    (size_t)0U,
+    (size_t)3U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_9d *row = &matrix_A->data[i0];
     Eurydice_arr_51 uu____0 = ZERO_d6_84();
     t_as_ntt->data[i0] = uu____0;
-    for (size_t i1 = (size_t)0U; i1 < array_to_slice_mut_cf3(row).meta; i1++)
-    {
+    KRML_MAYBE_FOR3(i1,
+      (size_t)0U,
+      (size_t)3U,
+      (size_t)1U,
       size_t j = i1;
       Eurydice_arr_51 *matrix_element = &row->data[j];
       Eurydice_arr_51 product = ntt_multiply_d6_84(matrix_element, &s_as_ntt->data[j]);
-      add_to_ring_element_d6_ab(&t_as_ntt->data[i0], &product);
-    }
-    add_standard_error_reduce_d6_84(&t_as_ntt->data[i0], &error_as_ntt->data[i0]);
-  }
+      add_to_ring_element_d6_ab(&t_as_ntt->data[i0], &product););
+    add_standard_error_reduce_d6_84(&t_as_ntt->data[i0], &error_as_ntt->data[i0]););
 }
 
 /**
@@ -4394,20 +4322,22 @@ compute_vector_u_ab(
     void *lvalue = (void *)0U;
     arr_struct.data[i] = call_mut_a8_ab(&lvalue););
   Eurydice_arr_9d result = arr_struct;
-  for (size_t i0 = (size_t)0U; i0 < array_to_slice_mut_b50(a_as_ntt).meta; i0++)
-  {
+  KRML_MAYBE_FOR3(i0,
+    (size_t)0U,
+    (size_t)3U,
+    (size_t)1U,
     size_t i1 = i0;
     Eurydice_arr_9d *row = &a_as_ntt->data[i1];
-    for (size_t i = (size_t)0U; i < array_to_slice_mut_cf3(row).meta; i++)
-    {
+    KRML_MAYBE_FOR3(i,
+      (size_t)0U,
+      (size_t)3U,
+      (size_t)1U,
       size_t j = i;
       Eurydice_arr_51 *a_element = &row->data[j];
       Eurydice_arr_51 product = ntt_multiply_d6_84(a_element, &r_as_ntt->data[j]);
-      add_to_ring_element_d6_ab(&result.data[i1], &product);
-    }
+      add_to_ring_element_d6_ab(&result.data[i1], &product););
     invert_ntt_montgomery_ab(&result.data[i1]);
-    add_error_reduce_d6_84(&result.data[i1], &error_1->data[i1]);
-  }
+    add_error_reduce_d6_84(&result.data[i1], &error_1->data[i1]););
   return result;
 }
 
@@ -4588,8 +4518,10 @@ with const generics
 static KRML_MUSTINLINE void
 compress_then_serialize_u_8c(Eurydice_arr_9d input, Eurydice_mut_borrow_slice_u8 out)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_mut_cf3(&input).meta; i++)
-  {
+  KRML_MAYBE_FOR3(i,
+    (size_t)0U,
+    (size_t)3U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_51 re = input.data[i0];
     Eurydice_mut_borrow_slice_u8
@@ -4603,8 +4535,7 @@ compress_then_serialize_u_8c(Eurydice_arr_9d input, Eurydice_mut_borrow_slice_u8
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_arr_b7 lvalue = compress_then_serialize_ring_element_u_a4(&re);
-    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_mut_d3(&lvalue), uint8_t);
-  }
+    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_mut_d3(&lvalue), uint8_t););
 }
 
 /**
@@ -5322,7 +5253,7 @@ deserialize_then_decompress_u_ed(Eurydice_arr_2c *ciphertext)
   (size_t
     i = (size_t)0U;
     i <
-      Eurydice_array_to_slice_mut_42(ciphertext).meta /
+      (size_t)1088U /
         (LIBCRUX_ML_KEM_CONSTANTS_COEFFICIENTS_IN_RING_ELEMENT * (size_t)10U / (size_t)8U);
     i++)
   {
@@ -6374,10 +6305,10 @@ shake128_squeeze_first_three_blocks_ac(Eurydice_arr_05 *st)
   Eurydice_arr_b0 out2 = { .data = { 0U } };
   Eurydice_arr_b0 out3 = { .data = { 0U } };
   libcrux_sha3_avx2_x4_incremental_shake128_squeeze_first_three_blocks(st,
-    Eurydice_array_to_slice_mut_850(&out0),
-    Eurydice_array_to_slice_mut_850(&out1),
-    Eurydice_array_to_slice_mut_850(&out2),
-    Eurydice_array_to_slice_mut_850(&out3));
+    Eurydice_array_to_slice_mut_85(&out0),
+    Eurydice_array_to_slice_mut_85(&out1),
+    Eurydice_array_to_slice_mut_85(&out2),
+    Eurydice_array_to_slice_mut_85(&out3));
   out.data[0U] = out0;
   out.data[1U] = out1;
   out.data[2U] = out2;
@@ -6695,20 +6626,6 @@ static KRML_MUSTINLINE Eurydice_arr_c5 sample_from_xof_6c0(Eurydice_arr_c50 *see
 }
 
 /**
-A monomorphic instance of Eurydice.array_to_slice_mut
-with types libcrux_ml_kem_polynomial_PolynomialRingElement libcrux_ml_kem_vector_avx2_SIMD256Vector
-with const generics
-- N= 4
-*/
-static dst_ref_mut_fb array_to_slice_mut_cf2(Eurydice_arr_c5 *a)
-{
-  dst_ref_mut_fb lit;
-  lit.ptr = a->data;
-  lit.meta = (size_t)4U;
-  return lit;
-}
-
-/**
 A monomorphic instance of libcrux_ml_kem.matrix.sample_matrix_A
 with types libcrux_ml_kem_vector_avx2_SIMD256Vector, libcrux_ml_kem_hash_functions_avx2_Simd256Hash
 with const generics
@@ -6742,8 +6659,10 @@ sample_matrix_A_6c0(Eurydice_arr_43 *A_transpose, Eurydice_arr_48 *seed, bool tr
       seeds.data[j].data[32U] = (uint8_t)i1;
       seeds.data[j].data[33U] = (uint8_t)j;);
     Eurydice_arr_c5 sampled = sample_from_xof_6c0(&seeds);
-    for (size_t i = (size_t)0U; i < array_to_slice_mut_cf2(&sampled).meta; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (size_t)0U,
+      (size_t)4U,
+      (size_t)1U,
       size_t j = i;
       Eurydice_arr_51 sample = sampled.data[j];
       if (transpose)
@@ -6753,8 +6672,7 @@ sample_matrix_A_6c0(Eurydice_arr_43 *A_transpose, Eurydice_arr_48 *seed, bool tr
       else
       {
         A_transpose->data[i1].data[j] = sample;
-      }
-    });
+      }););
 }
 
 /**
@@ -6819,8 +6737,10 @@ with const generics
 static KRML_MUSTINLINE void
 serialize_vector_42(Eurydice_arr_c5 *key, Eurydice_mut_borrow_slice_u8 out)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_mut_cf2(key).meta; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (size_t)0U,
+    (size_t)4U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_51 re = key->data[i0];
     Eurydice_mut_borrow_slice_u8
@@ -6834,8 +6754,7 @@ serialize_vector_42(Eurydice_arr_c5 *key, Eurydice_mut_borrow_slice_u8 out)
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_arr_cc lvalue = serialize_uncompressed_ring_element_84(&re);
-    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_mut_fe(&lvalue), uint8_t);
-  }
+    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_mut_fe(&lvalue), uint8_t););
 }
 
 /**
@@ -7163,8 +7082,10 @@ sample_matrix_A_b30(Eurydice_arr_43 *A_transpose, Eurydice_arr_48 *seed, bool tr
       seeds.data[j].data[32U] = (uint8_t)i1;
       seeds.data[j].data[33U] = (uint8_t)j;);
     Eurydice_arr_c5 sampled = sample_from_xof_b30(&seeds);
-    for (size_t i = (size_t)0U; i < array_to_slice_mut_cf2(&sampled).meta; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (size_t)0U,
+      (size_t)4U,
+      (size_t)1U,
       size_t j = i;
       Eurydice_arr_51 sample = sampled.data[j];
       if (transpose)
@@ -7174,8 +7095,7 @@ sample_matrix_A_b30(Eurydice_arr_43 *A_transpose, Eurydice_arr_48 *seed, bool tr
       else
       {
         A_transpose->data[i1].data[j] = sample;
-      }
-    });
+      }););
 }
 
 /**
@@ -7484,32 +7404,6 @@ static Eurydice_arr_51 call_mut_73_220(void **_)
 }
 
 /**
-A monomorphic instance of Eurydice.dst_ref_mut
-with types Eurydice_arr_c5, size_t
-
-*/
-typedef struct dst_ref_mut_df_s
-{
-  Eurydice_arr_c5 *ptr;
-  size_t meta;
-}
-dst_ref_mut_df;
-
-/**
-A monomorphic instance of Eurydice.array_to_slice_mut
-with types Eurydice_arr libcrux_ml_kem_polynomial_PolynomialRingElement libcrux_ml_kem_vector_avx2_SIMD256Vector[[$4size_t]]
-with const generics
-- N= 4
-*/
-static dst_ref_mut_df array_to_slice_mut_7c(Eurydice_arr_43 *a)
-{
-  dst_ref_mut_df lit;
-  lit.ptr = a->data;
-  lit.meta = (size_t)4U;
-  return lit;
-}
-
-/**
  Given two polynomial ring elements `lhs` and `rhs`, compute the pointwise
  sum of their constituent coefficients.
 */
@@ -7522,11 +7416,12 @@ with const generics
 static KRML_MUSTINLINE void
 add_to_ring_element_42(Eurydice_arr_51 *myself, Eurydice_arr_51 *rhs)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_mut_85(myself).meta; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (size_t)0U,
+    (size_t)16U,
+    (size_t)1U,
     size_t i0 = i;
-    myself->data[i0] = libcrux_ml_kem_vector_avx2_add_f5(myself->data[i0], &rhs->data[i0]);
-  }
+    myself->data[i0] = libcrux_ml_kem_vector_avx2_add_f5(myself->data[i0], &rhs->data[i0]););
 }
 
 /**
@@ -7561,21 +7456,23 @@ compute_As_plus_e_42(
   Eurydice_arr_c5 *error_as_ntt
 )
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_mut_7c(matrix_A).meta; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (size_t)0U,
+    (size_t)4U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_c5 *row = &matrix_A->data[i0];
     Eurydice_arr_51 uu____0 = ZERO_d6_84();
     t_as_ntt->data[i0] = uu____0;
-    for (size_t i1 = (size_t)0U; i1 < array_to_slice_mut_cf2(row).meta; i1++)
-    {
+    KRML_MAYBE_FOR4(i1,
+      (size_t)0U,
+      (size_t)4U,
+      (size_t)1U,
       size_t j = i1;
       Eurydice_arr_51 *matrix_element = &row->data[j];
       Eurydice_arr_51 product = ntt_multiply_d6_84(matrix_element, &s_as_ntt->data[j]);
-      add_to_ring_element_d6_42(&t_as_ntt->data[i0], &product);
-    }
-    add_standard_error_reduce_d6_84(&t_as_ntt->data[i0], &error_as_ntt->data[i0]);
-  }
+      add_to_ring_element_d6_42(&t_as_ntt->data[i0], &product););
+    add_standard_error_reduce_d6_84(&t_as_ntt->data[i0], &error_as_ntt->data[i0]););
 }
 
 /**
@@ -7982,20 +7879,22 @@ compute_vector_u_42(
     void *lvalue = (void *)0U;
     arr_struct.data[i] = call_mut_a8_42(&lvalue););
   Eurydice_arr_c5 result = arr_struct;
-  for (size_t i0 = (size_t)0U; i0 < array_to_slice_mut_7c(a_as_ntt).meta; i0++)
-  {
+  KRML_MAYBE_FOR4(i0,
+    (size_t)0U,
+    (size_t)4U,
+    (size_t)1U,
     size_t i1 = i0;
     Eurydice_arr_c5 *row = &a_as_ntt->data[i1];
-    for (size_t i = (size_t)0U; i < array_to_slice_mut_cf2(row).meta; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (size_t)0U,
+      (size_t)4U,
+      (size_t)1U,
       size_t j = i;
       Eurydice_arr_51 *a_element = &row->data[j];
       Eurydice_arr_51 product = ntt_multiply_d6_84(a_element, &r_as_ntt->data[j]);
-      add_to_ring_element_d6_42(&result.data[i1], &product);
-    }
+      add_to_ring_element_d6_42(&result.data[i1], &product););
     invert_ntt_montgomery_42(&result.data[i1]);
-    add_error_reduce_d6_84(&result.data[i1], &error_1->data[i1]);
-  }
+    add_error_reduce_d6_84(&result.data[i1], &error_1->data[i1]););
   return result;
 }
 
@@ -8056,8 +7955,10 @@ with const generics
 static KRML_MUSTINLINE void
 compress_then_serialize_u_c9(Eurydice_arr_c5 input, Eurydice_mut_borrow_slice_u8 out)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_mut_cf2(&input).meta; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (size_t)0U,
+    (size_t)4U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_51 re = input.data[i0];
     Eurydice_mut_borrow_slice_u8
@@ -8071,8 +7972,7 @@ compress_then_serialize_u_c9(Eurydice_arr_c5 input, Eurydice_mut_borrow_slice_u8
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_arr_790 lvalue = compress_then_serialize_ring_element_u_6f(&re);
-    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_mut_89(&lvalue), uint8_t);
-  }
+    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_mut_89(&lvalue), uint8_t););
 }
 
 /**
@@ -8403,7 +8303,7 @@ deserialize_then_decompress_u_1e(Eurydice_arr_00 *ciphertext)
   (size_t
     i = (size_t)0U;
     i <
-      Eurydice_array_to_slice_mut_4e(ciphertext).meta /
+      (size_t)1568U /
         (LIBCRUX_ML_KEM_CONSTANTS_COEFFICIENTS_IN_RING_ELEMENT * (size_t)11U / (size_t)8U);
     i++)
   {
@@ -9238,10 +9138,10 @@ shake128_squeeze_first_three_blocks_fd(Eurydice_arr_05 *st)
   Eurydice_arr_b0 out2 = { .data = { 0U } };
   Eurydice_arr_b0 out3 = { .data = { 0U } };
   libcrux_sha3_avx2_x4_incremental_shake128_squeeze_first_three_blocks(st,
-    Eurydice_array_to_slice_mut_850(&out0),
-    Eurydice_array_to_slice_mut_850(&out1),
-    Eurydice_array_to_slice_mut_850(&out2),
-    Eurydice_array_to_slice_mut_850(&out3));
+    Eurydice_array_to_slice_mut_85(&out0),
+    Eurydice_array_to_slice_mut_85(&out1),
+    Eurydice_array_to_slice_mut_85(&out2),
+    Eurydice_array_to_slice_mut_85(&out3));
   out.data[0U] = out0;
   out.data[1U] = out1;
   return out;
@@ -9552,20 +9452,6 @@ static KRML_MUSTINLINE Eurydice_arr_d3 sample_from_xof_6c(Eurydice_arr_f90 *seed
 }
 
 /**
-A monomorphic instance of Eurydice.array_to_slice_mut
-with types libcrux_ml_kem_polynomial_PolynomialRingElement libcrux_ml_kem_vector_avx2_SIMD256Vector
-with const generics
-- N= 2
-*/
-static dst_ref_mut_fb array_to_slice_mut_cf(Eurydice_arr_d3 *a)
-{
-  dst_ref_mut_fb lit;
-  lit.ptr = a->data;
-  lit.meta = (size_t)2U;
-  return lit;
-}
-
-/**
 A monomorphic instance of libcrux_ml_kem.matrix.sample_matrix_A
 with types libcrux_ml_kem_vector_avx2_SIMD256Vector, libcrux_ml_kem_hash_functions_avx2_Simd256Hash
 with const generics
@@ -9599,8 +9485,10 @@ sample_matrix_A_6c(Eurydice_arr_9a *A_transpose, Eurydice_arr_48 *seed, bool tra
       seeds.data[j].data[32U] = (uint8_t)i1;
       seeds.data[j].data[33U] = (uint8_t)j;);
     Eurydice_arr_d3 sampled = sample_from_xof_6c(&seeds);
-    for (size_t i = (size_t)0U; i < array_to_slice_mut_cf(&sampled).meta; i++)
-    {
+    KRML_MAYBE_FOR2(i,
+      (size_t)0U,
+      (size_t)2U,
+      (size_t)1U,
       size_t j = i;
       Eurydice_arr_51 sample = sampled.data[j];
       if (transpose)
@@ -9610,8 +9498,7 @@ sample_matrix_A_6c(Eurydice_arr_9a *A_transpose, Eurydice_arr_48 *seed, bool tra
       else
       {
         A_transpose->data[i1].data[j] = sample;
-      }
-    });
+      }););
 }
 
 /**
@@ -9676,8 +9563,10 @@ with const generics
 static KRML_MUSTINLINE void
 serialize_vector_89(Eurydice_arr_d3 *key, Eurydice_mut_borrow_slice_u8 out)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_mut_cf(key).meta; i++)
-  {
+  KRML_MAYBE_FOR2(i,
+    (size_t)0U,
+    (size_t)2U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_51 re = key->data[i0];
     Eurydice_mut_borrow_slice_u8
@@ -9691,8 +9580,7 @@ serialize_vector_89(Eurydice_arr_d3 *key, Eurydice_mut_borrow_slice_u8 out)
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_arr_cc lvalue = serialize_uncompressed_ring_element_84(&re);
-    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_mut_fe(&lvalue), uint8_t);
-  }
+    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_mut_fe(&lvalue), uint8_t););
 }
 
 /**
@@ -10018,8 +9906,10 @@ sample_matrix_A_b3(Eurydice_arr_9a *A_transpose, Eurydice_arr_48 *seed, bool tra
       seeds.data[j].data[32U] = (uint8_t)i1;
       seeds.data[j].data[33U] = (uint8_t)j;);
     Eurydice_arr_d3 sampled = sample_from_xof_b3(&seeds);
-    for (size_t i = (size_t)0U; i < array_to_slice_mut_cf(&sampled).meta; i++)
-    {
+    KRML_MAYBE_FOR2(i,
+      (size_t)0U,
+      (size_t)2U,
+      (size_t)1U,
       size_t j = i;
       Eurydice_arr_51 sample = sampled.data[j];
       if (transpose)
@@ -10029,8 +9919,7 @@ sample_matrix_A_b3(Eurydice_arr_9a *A_transpose, Eurydice_arr_48 *seed, bool tra
       else
       {
         A_transpose->data[i1].data[j] = sample;
-      }
-    });
+      }););
 }
 
 /**
@@ -10346,32 +10235,6 @@ static Eurydice_arr_51 call_mut_73_22(void **_)
 }
 
 /**
-A monomorphic instance of Eurydice.dst_ref_mut
-with types Eurydice_arr_d3, size_t
-
-*/
-typedef struct dst_ref_mut_08_s
-{
-  Eurydice_arr_d3 *ptr;
-  size_t meta;
-}
-dst_ref_mut_08;
-
-/**
-A monomorphic instance of Eurydice.array_to_slice_mut
-with types Eurydice_arr libcrux_ml_kem_polynomial_PolynomialRingElement libcrux_ml_kem_vector_avx2_SIMD256Vector[[$2size_t]]
-with const generics
-- N= 2
-*/
-static dst_ref_mut_08 array_to_slice_mut_f4(Eurydice_arr_9a *a)
-{
-  dst_ref_mut_08 lit;
-  lit.ptr = a->data;
-  lit.meta = (size_t)2U;
-  return lit;
-}
-
-/**
  Given two polynomial ring elements `lhs` and `rhs`, compute the pointwise
  sum of their constituent coefficients.
 */
@@ -10384,11 +10247,12 @@ with const generics
 static KRML_MUSTINLINE void
 add_to_ring_element_89(Eurydice_arr_51 *myself, Eurydice_arr_51 *rhs)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_mut_85(myself).meta; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (size_t)0U,
+    (size_t)16U,
+    (size_t)1U,
     size_t i0 = i;
-    myself->data[i0] = libcrux_ml_kem_vector_avx2_add_f5(myself->data[i0], &rhs->data[i0]);
-  }
+    myself->data[i0] = libcrux_ml_kem_vector_avx2_add_f5(myself->data[i0], &rhs->data[i0]););
 }
 
 /**
@@ -10423,21 +10287,23 @@ compute_As_plus_e_89(
   Eurydice_arr_d3 *error_as_ntt
 )
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_mut_f4(matrix_A).meta; i++)
-  {
+  KRML_MAYBE_FOR2(i,
+    (size_t)0U,
+    (size_t)2U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_d3 *row = &matrix_A->data[i0];
     Eurydice_arr_51 uu____0 = ZERO_d6_84();
     t_as_ntt->data[i0] = uu____0;
-    for (size_t i1 = (size_t)0U; i1 < array_to_slice_mut_cf(row).meta; i1++)
-    {
+    KRML_MAYBE_FOR2(i1,
+      (size_t)0U,
+      (size_t)2U,
+      (size_t)1U,
       size_t j = i1;
       Eurydice_arr_51 *matrix_element = &row->data[j];
       Eurydice_arr_51 product = ntt_multiply_d6_84(matrix_element, &s_as_ntt->data[j]);
-      add_to_ring_element_d6_89(&t_as_ntt->data[i0], &product);
-    }
-    add_standard_error_reduce_d6_84(&t_as_ntt->data[i0], &error_as_ntt->data[i0]);
-  }
+      add_to_ring_element_d6_89(&t_as_ntt->data[i0], &product););
+    add_standard_error_reduce_d6_84(&t_as_ntt->data[i0], &error_as_ntt->data[i0]););
 }
 
 /**
@@ -10884,20 +10750,22 @@ compute_vector_u_89(
     void *lvalue = (void *)0U;
     arr_struct.data[i] = call_mut_a8_89(&lvalue););
   Eurydice_arr_d3 result = arr_struct;
-  for (size_t i0 = (size_t)0U; i0 < array_to_slice_mut_f4(a_as_ntt).meta; i0++)
-  {
+  KRML_MAYBE_FOR2(i0,
+    (size_t)0U,
+    (size_t)2U,
+    (size_t)1U,
     size_t i1 = i0;
     Eurydice_arr_d3 *row = &a_as_ntt->data[i1];
-    for (size_t i = (size_t)0U; i < array_to_slice_mut_cf(row).meta; i++)
-    {
+    KRML_MAYBE_FOR2(i,
+      (size_t)0U,
+      (size_t)2U,
+      (size_t)1U,
       size_t j = i;
       Eurydice_arr_51 *a_element = &row->data[j];
       Eurydice_arr_51 product = ntt_multiply_d6_84(a_element, &r_as_ntt->data[j]);
-      add_to_ring_element_d6_89(&result.data[i1], &product);
-    }
+      add_to_ring_element_d6_89(&result.data[i1], &product););
     invert_ntt_montgomery_89(&result.data[i1]);
-    add_error_reduce_d6_84(&result.data[i1], &error_1->data[i1]);
-  }
+    add_error_reduce_d6_84(&result.data[i1], &error_1->data[i1]););
   return result;
 }
 
@@ -10916,8 +10784,10 @@ with const generics
 static KRML_MUSTINLINE void
 compress_then_serialize_u_2d(Eurydice_arr_d3 input, Eurydice_mut_borrow_slice_u8 out)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_mut_cf(&input).meta; i++)
-  {
+  KRML_MAYBE_FOR2(i,
+    (size_t)0U,
+    (size_t)2U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_51 re = input.data[i0];
     Eurydice_mut_borrow_slice_u8
@@ -10931,8 +10801,7 @@ compress_then_serialize_u_2d(Eurydice_arr_d3 input, Eurydice_mut_borrow_slice_u8
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_arr_b7 lvalue = compress_then_serialize_ring_element_u_a4(&re);
-    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_mut_d3(&lvalue), uint8_t);
-  }
+    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_mut_d3(&lvalue), uint8_t););
 }
 
 /**
@@ -11228,7 +11097,7 @@ deserialize_then_decompress_u_ba(Eurydice_arr_56 *ciphertext)
   (size_t
     i = (size_t)0U;
     i <
-      Eurydice_array_to_slice_mut_ee(ciphertext).meta /
+      (size_t)768U /
         (LIBCRUX_ML_KEM_CONSTANTS_COEFFICIENTS_IN_RING_ELEMENT * (size_t)10U / (size_t)8U);
     i++)
   {

--- a/out/test-libcrux-no-const/libcrux_mlkem_portable.c
+++ b/out/test-libcrux-no-const/libcrux_mlkem_portable.c
@@ -1868,7 +1868,7 @@ static inline Eurydice_arr_e0 shake128_squeeze_first_three_blocks_ac(Eurydice_ar
     (size_t)1U,
     size_t i0 = i;
     libcrux_sha3_portable_incremental_shake128_squeeze_first_three_blocks(&st->data[i0],
-      Eurydice_array_to_slice_mut_850(&out.data[i0])););
+      Eurydice_array_to_slice_mut_85(&out.data[i0])););
   return out;
 }
 
@@ -2245,32 +2245,6 @@ static KRML_MUSTINLINE Eurydice_arr_cf sample_from_xof_2b1(Eurydice_arr_c50 *see
 }
 
 /**
-A monomorphic instance of Eurydice.dst_ref_mut
-with types libcrux_ml_kem_polynomial_PolynomialRingElement_1d, size_t
-
-*/
-typedef struct dst_ref_mut_b0_s
-{
-  Eurydice_arr_b9 *ptr;
-  size_t meta;
-}
-dst_ref_mut_b0;
-
-/**
-A monomorphic instance of Eurydice.array_to_slice_mut
-with types libcrux_ml_kem_polynomial_PolynomialRingElement libcrux_ml_kem_vector_portable_vector_type_PortableVector
-with const generics
-- N= 4
-*/
-static dst_ref_mut_b0 array_to_slice_mut_cf4(Eurydice_arr_cf *a)
-{
-  dst_ref_mut_b0 lit;
-  lit.ptr = a->data;
-  lit.meta = (size_t)4U;
-  return lit;
-}
-
-/**
 A monomorphic instance of libcrux_ml_kem.matrix.sample_matrix_A
 with types libcrux_ml_kem_vector_portable_vector_type_PortableVector, libcrux_ml_kem_hash_functions_portable_PortableHash[[$4size_t]]
 with const generics
@@ -2304,8 +2278,10 @@ sample_matrix_A_2b1(Eurydice_arr_5c *A_transpose, Eurydice_arr_48 *seed, bool tr
       seeds.data[j].data[32U] = (uint8_t)i1;
       seeds.data[j].data[33U] = (uint8_t)j;);
     Eurydice_arr_cf sampled = sample_from_xof_2b1(&seeds);
-    for (size_t i = (size_t)0U; i < array_to_slice_mut_cf4(&sampled).meta; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (size_t)0U,
+      (size_t)4U,
+      (size_t)1U,
       size_t j = i;
       Eurydice_arr_b9 sample = sampled.data[j];
       if (transpose)
@@ -2315,8 +2291,7 @@ sample_matrix_A_2b1(Eurydice_arr_5c *A_transpose, Eurydice_arr_48 *seed, bool tr
       else
       {
         A_transpose->data[i1].data[j] = sample;
-      }
-    });
+      }););
 }
 
 /**
@@ -2420,8 +2395,10 @@ with const generics
 static KRML_MUSTINLINE void
 serialize_vector_d0(Eurydice_arr_cf *key, Eurydice_mut_borrow_slice_u8 out)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_mut_cf4(key).meta; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (size_t)0U,
+    (size_t)4U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_b9 re = key->data[i0];
     Eurydice_mut_borrow_slice_u8
@@ -2435,8 +2412,7 @@ serialize_vector_d0(Eurydice_arr_cf *key, Eurydice_mut_borrow_slice_u8 out)
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_arr_cc lvalue = serialize_uncompressed_ring_element_ea(&re);
-    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_mut_fe(&lvalue), uint8_t);
-  }
+    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_mut_fe(&lvalue), uint8_t););
 }
 
 /**
@@ -3399,32 +3375,6 @@ static Eurydice_arr_b9 call_mut_73_1c1(void **_)
 }
 
 /**
-A monomorphic instance of Eurydice.dst_ref_mut
-with types Eurydice_arr_cf, size_t
-
-*/
-typedef struct dst_ref_mut_16_s
-{
-  Eurydice_arr_cf *ptr;
-  size_t meta;
-}
-dst_ref_mut_16;
-
-/**
-A monomorphic instance of Eurydice.array_to_slice_mut
-with types Eurydice_arr libcrux_ml_kem_polynomial_PolynomialRingElement libcrux_ml_kem_vector_portable_vector_type_PortableVector[[$4size_t]]
-with const generics
-- N= 4
-*/
-static dst_ref_mut_16 array_to_slice_mut_7c0(Eurydice_arr_5c *a)
-{
-  dst_ref_mut_16 lit;
-  lit.ptr = a->data;
-  lit.meta = (size_t)4U;
-  return lit;
-}
-
-/**
  Given two `KyberPolynomialRingElement`s in their NTT representations,
  compute their product. Given two polynomials in the NTT domain `f^` and `ĵ`,
  the `iᵗʰ` coefficient of the product `k̂` is determined by the calculation:
@@ -3493,32 +3443,6 @@ ntt_multiply_d6_ea(Eurydice_arr_b9 *self, Eurydice_arr_b9 *rhs)
 }
 
 /**
-A monomorphic instance of Eurydice.dst_ref_mut
-with types libcrux_ml_kem_vector_portable_vector_type_PortableVector, size_t
-
-*/
-typedef struct dst_ref_mut_f3_s
-{
-  Eurydice_arr_e2 *ptr;
-  size_t meta;
-}
-dst_ref_mut_f3;
-
-/**
-A monomorphic instance of Eurydice.array_to_slice_mut
-with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
-with const generics
-- N= 16
-*/
-static dst_ref_mut_f3 array_to_slice_mut_24(Eurydice_arr_b9 *a)
-{
-  dst_ref_mut_f3 lit;
-  lit.ptr = a->data;
-  lit.meta = (size_t)16U;
-  return lit;
-}
-
-/**
  Given two polynomial ring elements `lhs` and `rhs`, compute the pointwise
  sum of their constituent coefficients.
 */
@@ -3531,13 +3455,14 @@ with const generics
 static KRML_MUSTINLINE void
 add_to_ring_element_d0(Eurydice_arr_b9 *myself, Eurydice_arr_b9 *rhs)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_mut_24(myself).meta; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (size_t)0U,
+    (size_t)16U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_e2
     uu____0 = libcrux_ml_kem_vector_portable_add_b8(myself->data[i0], &rhs->data[i0]);
-    myself->data[i0] = uu____0;
-  }
+    myself->data[i0] = uu____0;);
 }
 
 /**
@@ -3620,21 +3545,23 @@ compute_As_plus_e_d0(
   Eurydice_arr_cf *error_as_ntt
 )
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_mut_7c0(matrix_A).meta; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (size_t)0U,
+    (size_t)4U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_cf *row = &matrix_A->data[i0];
     Eurydice_arr_b9 uu____0 = ZERO_d6_ea();
     t_as_ntt->data[i0] = uu____0;
-    for (size_t i1 = (size_t)0U; i1 < array_to_slice_mut_cf4(row).meta; i1++)
-    {
+    KRML_MAYBE_FOR4(i1,
+      (size_t)0U,
+      (size_t)4U,
+      (size_t)1U,
       size_t j = i1;
       Eurydice_arr_b9 *matrix_element = &row->data[j];
       Eurydice_arr_b9 product = ntt_multiply_d6_ea(matrix_element, &s_as_ntt->data[j]);
-      add_to_ring_element_d6_d0(&t_as_ntt->data[i0], &product);
-    }
-    add_standard_error_reduce_d6_ea(&t_as_ntt->data[i0], &error_as_ntt->data[i0]);
-  }
+      add_to_ring_element_d6_d0(&t_as_ntt->data[i0], &product););
+    add_standard_error_reduce_d6_ea(&t_as_ntt->data[i0], &error_as_ntt->data[i0]););
 }
 
 /**
@@ -4229,20 +4156,22 @@ compute_vector_u_d0(
     void *lvalue = (void *)0U;
     arr_struct.data[i] = call_mut_a8_d0(&lvalue););
   Eurydice_arr_cf result = arr_struct;
-  for (size_t i0 = (size_t)0U; i0 < array_to_slice_mut_7c0(a_as_ntt).meta; i0++)
-  {
+  KRML_MAYBE_FOR4(i0,
+    (size_t)0U,
+    (size_t)4U,
+    (size_t)1U,
     size_t i1 = i0;
     Eurydice_arr_cf *row = &a_as_ntt->data[i1];
-    for (size_t i = (size_t)0U; i < array_to_slice_mut_cf4(row).meta; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (size_t)0U,
+      (size_t)4U,
+      (size_t)1U,
       size_t j = i;
       Eurydice_arr_b9 *a_element = &row->data[j];
       Eurydice_arr_b9 product = ntt_multiply_d6_ea(a_element, &r_as_ntt->data[j]);
-      add_to_ring_element_d6_d0(&result.data[i1], &product);
-    }
+      add_to_ring_element_d6_d0(&result.data[i1], &product););
     invert_ntt_montgomery_d0(&result.data[i1]);
-    add_error_reduce_d6_ea(&result.data[i1], &error_1->data[i1]);
-  }
+    add_error_reduce_d6_ea(&result.data[i1], &error_1->data[i1]););
   return result;
 }
 
@@ -4367,8 +4296,10 @@ with const generics
 static KRML_MUSTINLINE void
 compress_then_serialize_u_2f(Eurydice_arr_cf input, Eurydice_mut_borrow_slice_u8 out)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_mut_cf4(&input).meta; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (size_t)0U,
+    (size_t)4U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_b9 re = input.data[i0];
     Eurydice_mut_borrow_slice_u8
@@ -4382,8 +4313,7 @@ compress_then_serialize_u_2f(Eurydice_arr_cf input, Eurydice_mut_borrow_slice_u8
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_arr_790 lvalue = compress_then_serialize_ring_element_u_82(&re);
-    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_mut_89(&lvalue), uint8_t);
-  }
+    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_mut_89(&lvalue), uint8_t););
 }
 
 /**
@@ -5036,7 +4966,7 @@ deserialize_then_decompress_u_00(Eurydice_arr_00 *ciphertext)
   (size_t
     i = (size_t)0U;
     i <
-      Eurydice_array_to_slice_mut_4e(ciphertext).meta /
+      (size_t)1568U /
         (LIBCRUX_ML_KEM_CONSTANTS_COEFFICIENTS_IN_RING_ELEMENT * (size_t)11U / (size_t)8U);
     i++)
   {
@@ -6011,7 +5941,7 @@ static inline Eurydice_arr_31 shake128_squeeze_first_three_blocks_fd(Eurydice_ar
     (size_t)1U,
     size_t i0 = i;
     libcrux_sha3_portable_incremental_shake128_squeeze_first_three_blocks(&st->data[i0],
-      Eurydice_array_to_slice_mut_850(&out.data[i0])););
+      Eurydice_array_to_slice_mut_85(&out.data[i0])););
   return out;
 }
 
@@ -6323,20 +6253,6 @@ static KRML_MUSTINLINE Eurydice_arr_3d0 sample_from_xof_2b0(Eurydice_arr_f90 *se
 }
 
 /**
-A monomorphic instance of Eurydice.array_to_slice_mut
-with types libcrux_ml_kem_polynomial_PolynomialRingElement libcrux_ml_kem_vector_portable_vector_type_PortableVector
-with const generics
-- N= 2
-*/
-static dst_ref_mut_b0 array_to_slice_mut_cf1(Eurydice_arr_3d0 *a)
-{
-  dst_ref_mut_b0 lit;
-  lit.ptr = a->data;
-  lit.meta = (size_t)2U;
-  return lit;
-}
-
-/**
 A monomorphic instance of libcrux_ml_kem.matrix.sample_matrix_A
 with types libcrux_ml_kem_vector_portable_vector_type_PortableVector, libcrux_ml_kem_hash_functions_portable_PortableHash[[$2size_t]]
 with const generics
@@ -6370,8 +6286,10 @@ sample_matrix_A_2b0(Eurydice_arr_6d0 *A_transpose, Eurydice_arr_48 *seed, bool t
       seeds.data[j].data[32U] = (uint8_t)i1;
       seeds.data[j].data[33U] = (uint8_t)j;);
     Eurydice_arr_3d0 sampled = sample_from_xof_2b0(&seeds);
-    for (size_t i = (size_t)0U; i < array_to_slice_mut_cf1(&sampled).meta; i++)
-    {
+    KRML_MAYBE_FOR2(i,
+      (size_t)0U,
+      (size_t)2U,
+      (size_t)1U,
       size_t j = i;
       Eurydice_arr_b9 sample = sampled.data[j];
       if (transpose)
@@ -6381,8 +6299,7 @@ sample_matrix_A_2b0(Eurydice_arr_6d0 *A_transpose, Eurydice_arr_48 *seed, bool t
       else
       {
         A_transpose->data[i1].data[j] = sample;
-      }
-    });
+      }););
 }
 
 /**
@@ -6447,8 +6364,10 @@ with const generics
 static KRML_MUSTINLINE void
 serialize_vector_a0(Eurydice_arr_3d0 *key, Eurydice_mut_borrow_slice_u8 out)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_mut_cf1(key).meta; i++)
-  {
+  KRML_MAYBE_FOR2(i,
+    (size_t)0U,
+    (size_t)2U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_b9 re = key->data[i0];
     Eurydice_mut_borrow_slice_u8
@@ -6462,8 +6381,7 @@ serialize_vector_a0(Eurydice_arr_3d0 *key, Eurydice_mut_borrow_slice_u8 out)
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_arr_cc lvalue = serialize_uncompressed_ring_element_ea(&re);
-    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_mut_fe(&lvalue), uint8_t);
-  }
+    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_mut_fe(&lvalue), uint8_t););
 }
 
 /**
@@ -7063,32 +6981,6 @@ static Eurydice_arr_b9 call_mut_73_1c0(void **_)
 }
 
 /**
-A monomorphic instance of Eurydice.dst_ref_mut
-with types Eurydice_arr_3d0, size_t
-
-*/
-typedef struct dst_ref_mut_d9_s
-{
-  Eurydice_arr_3d0 *ptr;
-  size_t meta;
-}
-dst_ref_mut_d9;
-
-/**
-A monomorphic instance of Eurydice.array_to_slice_mut
-with types Eurydice_arr libcrux_ml_kem_polynomial_PolynomialRingElement libcrux_ml_kem_vector_portable_vector_type_PortableVector[[$2size_t]]
-with const generics
-- N= 2
-*/
-static dst_ref_mut_d9 array_to_slice_mut_f40(Eurydice_arr_6d0 *a)
-{
-  dst_ref_mut_d9 lit;
-  lit.ptr = a->data;
-  lit.meta = (size_t)2U;
-  return lit;
-}
-
-/**
  Given two polynomial ring elements `lhs` and `rhs`, compute the pointwise
  sum of their constituent coefficients.
 */
@@ -7101,13 +6993,14 @@ with const generics
 static KRML_MUSTINLINE void
 add_to_ring_element_a0(Eurydice_arr_b9 *myself, Eurydice_arr_b9 *rhs)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_mut_24(myself).meta; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (size_t)0U,
+    (size_t)16U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_e2
     uu____0 = libcrux_ml_kem_vector_portable_add_b8(myself->data[i0], &rhs->data[i0]);
-    myself->data[i0] = uu____0;
-  }
+    myself->data[i0] = uu____0;);
 }
 
 /**
@@ -7142,21 +7035,23 @@ compute_As_plus_e_a0(
   Eurydice_arr_3d0 *error_as_ntt
 )
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_mut_f40(matrix_A).meta; i++)
-  {
+  KRML_MAYBE_FOR2(i,
+    (size_t)0U,
+    (size_t)2U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_3d0 *row = &matrix_A->data[i0];
     Eurydice_arr_b9 uu____0 = ZERO_d6_ea();
     t_as_ntt->data[i0] = uu____0;
-    for (size_t i1 = (size_t)0U; i1 < array_to_slice_mut_cf1(row).meta; i1++)
-    {
+    KRML_MAYBE_FOR2(i1,
+      (size_t)0U,
+      (size_t)2U,
+      (size_t)1U,
       size_t j = i1;
       Eurydice_arr_b9 *matrix_element = &row->data[j];
       Eurydice_arr_b9 product = ntt_multiply_d6_ea(matrix_element, &s_as_ntt->data[j]);
-      add_to_ring_element_d6_a0(&t_as_ntt->data[i0], &product);
-    }
-    add_standard_error_reduce_d6_ea(&t_as_ntt->data[i0], &error_as_ntt->data[i0]);
-  }
+      add_to_ring_element_d6_a0(&t_as_ntt->data[i0], &product););
+    add_standard_error_reduce_d6_ea(&t_as_ntt->data[i0], &error_as_ntt->data[i0]););
 }
 
 /**
@@ -7596,20 +7491,22 @@ compute_vector_u_a0(
     void *lvalue = (void *)0U;
     arr_struct.data[i] = call_mut_a8_a0(&lvalue););
   Eurydice_arr_3d0 result = arr_struct;
-  for (size_t i0 = (size_t)0U; i0 < array_to_slice_mut_f40(a_as_ntt).meta; i0++)
-  {
+  KRML_MAYBE_FOR2(i0,
+    (size_t)0U,
+    (size_t)2U,
+    (size_t)1U,
     size_t i1 = i0;
     Eurydice_arr_3d0 *row = &a_as_ntt->data[i1];
-    for (size_t i = (size_t)0U; i < array_to_slice_mut_cf1(row).meta; i++)
-    {
+    KRML_MAYBE_FOR2(i,
+      (size_t)0U,
+      (size_t)2U,
+      (size_t)1U,
       size_t j = i;
       Eurydice_arr_b9 *a_element = &row->data[j];
       Eurydice_arr_b9 product = ntt_multiply_d6_ea(a_element, &r_as_ntt->data[j]);
-      add_to_ring_element_d6_a0(&result.data[i1], &product);
-    }
+      add_to_ring_element_d6_a0(&result.data[i1], &product););
     invert_ntt_montgomery_a0(&result.data[i1]);
-    add_error_reduce_d6_ea(&result.data[i1], &error_1->data[i1]);
-  }
+    add_error_reduce_d6_ea(&result.data[i1], &error_1->data[i1]););
   return result;
 }
 
@@ -7668,8 +7565,10 @@ with const generics
 static KRML_MUSTINLINE void
 compress_then_serialize_u_6d(Eurydice_arr_3d0 input, Eurydice_mut_borrow_slice_u8 out)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_mut_cf1(&input).meta; i++)
-  {
+  KRML_MAYBE_FOR2(i,
+    (size_t)0U,
+    (size_t)2U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_b9 re = input.data[i0];
     Eurydice_mut_borrow_slice_u8
@@ -7683,8 +7582,7 @@ compress_then_serialize_u_6d(Eurydice_arr_3d0 input, Eurydice_mut_borrow_slice_u
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_arr_b7 lvalue = compress_then_serialize_ring_element_u_fe(&re);
-    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_mut_d3(&lvalue), uint8_t);
-  }
+    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_mut_d3(&lvalue), uint8_t););
 }
 
 /**
@@ -8015,7 +7913,7 @@ deserialize_then_decompress_u_86(Eurydice_arr_56 *ciphertext)
   (size_t
     i = (size_t)0U;
     i <
-      Eurydice_array_to_slice_mut_ee(ciphertext).meta /
+      (size_t)768U /
         (LIBCRUX_ML_KEM_CONSTANTS_COEFFICIENTS_IN_RING_ELEMENT * (size_t)10U / (size_t)8U);
     i++)
   {
@@ -8781,7 +8679,7 @@ static inline Eurydice_arr_55 shake128_squeeze_first_three_blocks_e0(Eurydice_ar
     (size_t)1U,
     size_t i0 = i;
     libcrux_sha3_portable_incremental_shake128_squeeze_first_three_blocks(&st->data[i0],
-      Eurydice_array_to_slice_mut_850(&out.data[i0])););
+      Eurydice_array_to_slice_mut_85(&out.data[i0])););
   return out;
 }
 
@@ -9095,20 +8993,6 @@ static KRML_MUSTINLINE Eurydice_arr_1d sample_from_xof_2b(Eurydice_arr_c3 *seeds
 }
 
 /**
-A monomorphic instance of Eurydice.array_to_slice_mut
-with types libcrux_ml_kem_polynomial_PolynomialRingElement libcrux_ml_kem_vector_portable_vector_type_PortableVector
-with const generics
-- N= 3
-*/
-static dst_ref_mut_b0 array_to_slice_mut_cf0(Eurydice_arr_1d *a)
-{
-  dst_ref_mut_b0 lit;
-  lit.ptr = a->data;
-  lit.meta = (size_t)3U;
-  return lit;
-}
-
-/**
 A monomorphic instance of libcrux_ml_kem.matrix.sample_matrix_A
 with types libcrux_ml_kem_vector_portable_vector_type_PortableVector, libcrux_ml_kem_hash_functions_portable_PortableHash[[$3size_t]]
 with const generics
@@ -9142,8 +9026,10 @@ sample_matrix_A_2b(Eurydice_arr_dd *A_transpose, Eurydice_arr_48 *seed, bool tra
       seeds.data[j].data[32U] = (uint8_t)i1;
       seeds.data[j].data[33U] = (uint8_t)j;);
     Eurydice_arr_1d sampled = sample_from_xof_2b(&seeds);
-    for (size_t i = (size_t)0U; i < array_to_slice_mut_cf0(&sampled).meta; i++)
-    {
+    KRML_MAYBE_FOR3(i,
+      (size_t)0U,
+      (size_t)3U,
+      (size_t)1U,
       size_t j = i;
       Eurydice_arr_b9 sample = sampled.data[j];
       if (transpose)
@@ -9153,8 +9039,7 @@ sample_matrix_A_2b(Eurydice_arr_dd *A_transpose, Eurydice_arr_48 *seed, bool tra
       else
       {
         A_transpose->data[i1].data[j] = sample;
-      }
-    });
+      }););
 }
 
 /**
@@ -9301,8 +9186,10 @@ with const generics
 static KRML_MUSTINLINE void
 serialize_vector_1b(Eurydice_arr_1d *key, Eurydice_mut_borrow_slice_u8 out)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_mut_cf0(key).meta; i++)
-  {
+  KRML_MAYBE_FOR3(i,
+    (size_t)0U,
+    (size_t)3U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_b9 re = key->data[i0];
     Eurydice_mut_borrow_slice_u8
@@ -9316,8 +9203,7 @@ serialize_vector_1b(Eurydice_arr_1d *key, Eurydice_mut_borrow_slice_u8 out)
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_arr_cc lvalue = serialize_uncompressed_ring_element_ea(&re);
-    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_mut_fe(&lvalue), uint8_t);
-  }
+    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_mut_fe(&lvalue), uint8_t););
 }
 
 /**
@@ -9905,32 +9791,6 @@ static Eurydice_arr_b9 call_mut_73_1c(void **_)
 }
 
 /**
-A monomorphic instance of Eurydice.dst_ref_mut
-with types Eurydice_arr_1d, size_t
-
-*/
-typedef struct dst_ref_mut_66_s
-{
-  Eurydice_arr_1d *ptr;
-  size_t meta;
-}
-dst_ref_mut_66;
-
-/**
-A monomorphic instance of Eurydice.array_to_slice_mut
-with types Eurydice_arr libcrux_ml_kem_polynomial_PolynomialRingElement libcrux_ml_kem_vector_portable_vector_type_PortableVector[[$3size_t]]
-with const generics
-- N= 3
-*/
-static dst_ref_mut_66 array_to_slice_mut_b5(Eurydice_arr_dd *a)
-{
-  dst_ref_mut_66 lit;
-  lit.ptr = a->data;
-  lit.meta = (size_t)3U;
-  return lit;
-}
-
-/**
  Given two polynomial ring elements `lhs` and `rhs`, compute the pointwise
  sum of their constituent coefficients.
 */
@@ -9943,13 +9803,14 @@ with const generics
 static KRML_MUSTINLINE void
 add_to_ring_element_1b(Eurydice_arr_b9 *myself, Eurydice_arr_b9 *rhs)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_mut_24(myself).meta; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (size_t)0U,
+    (size_t)16U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_e2
     uu____0 = libcrux_ml_kem_vector_portable_add_b8(myself->data[i0], &rhs->data[i0]);
-    myself->data[i0] = uu____0;
-  }
+    myself->data[i0] = uu____0;);
 }
 
 /**
@@ -9984,21 +9845,23 @@ compute_As_plus_e_1b(
   Eurydice_arr_1d *error_as_ntt
 )
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_mut_b5(matrix_A).meta; i++)
-  {
+  KRML_MAYBE_FOR3(i,
+    (size_t)0U,
+    (size_t)3U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_1d *row = &matrix_A->data[i0];
     Eurydice_arr_b9 uu____0 = ZERO_d6_ea();
     t_as_ntt->data[i0] = uu____0;
-    for (size_t i1 = (size_t)0U; i1 < array_to_slice_mut_cf0(row).meta; i1++)
-    {
+    KRML_MAYBE_FOR3(i1,
+      (size_t)0U,
+      (size_t)3U,
+      (size_t)1U,
       size_t j = i1;
       Eurydice_arr_b9 *matrix_element = &row->data[j];
       Eurydice_arr_b9 product = ntt_multiply_d6_ea(matrix_element, &s_as_ntt->data[j]);
-      add_to_ring_element_d6_1b(&t_as_ntt->data[i0], &product);
-    }
-    add_standard_error_reduce_d6_ea(&t_as_ntt->data[i0], &error_as_ntt->data[i0]);
-  }
+      add_to_ring_element_d6_1b(&t_as_ntt->data[i0], &product););
+    add_standard_error_reduce_d6_ea(&t_as_ntt->data[i0], &error_as_ntt->data[i0]););
 }
 
 /**
@@ -10405,20 +10268,22 @@ compute_vector_u_1b(
     void *lvalue = (void *)0U;
     arr_struct.data[i] = call_mut_a8_1b(&lvalue););
   Eurydice_arr_1d result = arr_struct;
-  for (size_t i0 = (size_t)0U; i0 < array_to_slice_mut_b5(a_as_ntt).meta; i0++)
-  {
+  KRML_MAYBE_FOR3(i0,
+    (size_t)0U,
+    (size_t)3U,
+    (size_t)1U,
     size_t i1 = i0;
     Eurydice_arr_1d *row = &a_as_ntt->data[i1];
-    for (size_t i = (size_t)0U; i < array_to_slice_mut_cf0(row).meta; i++)
-    {
+    KRML_MAYBE_FOR3(i,
+      (size_t)0U,
+      (size_t)3U,
+      (size_t)1U,
       size_t j = i;
       Eurydice_arr_b9 *a_element = &row->data[j];
       Eurydice_arr_b9 product = ntt_multiply_d6_ea(a_element, &r_as_ntt->data[j]);
-      add_to_ring_element_d6_1b(&result.data[i1], &product);
-    }
+      add_to_ring_element_d6_1b(&result.data[i1], &product););
     invert_ntt_montgomery_1b(&result.data[i1]);
-    add_error_reduce_d6_ea(&result.data[i1], &error_1->data[i1]);
-  }
+    add_error_reduce_d6_ea(&result.data[i1], &error_1->data[i1]););
   return result;
 }
 
@@ -10437,8 +10302,10 @@ with const generics
 static KRML_MUSTINLINE void
 compress_then_serialize_u_43(Eurydice_arr_1d input, Eurydice_mut_borrow_slice_u8 out)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_mut_cf0(&input).meta; i++)
-  {
+  KRML_MAYBE_FOR3(i,
+    (size_t)0U,
+    (size_t)3U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_b9 re = input.data[i0];
     Eurydice_mut_borrow_slice_u8
@@ -10452,8 +10319,7 @@ compress_then_serialize_u_43(Eurydice_arr_1d input, Eurydice_mut_borrow_slice_u8
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_arr_b7 lvalue = compress_then_serialize_ring_element_u_fe(&re);
-    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_mut_d3(&lvalue), uint8_t);
-  }
+    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_mut_d3(&lvalue), uint8_t););
 }
 
 /**
@@ -10749,7 +10615,7 @@ deserialize_then_decompress_u_6c(Eurydice_arr_2c *ciphertext)
   (size_t
     i = (size_t)0U;
     i <
-      Eurydice_array_to_slice_mut_42(ciphertext).meta /
+      (size_t)1088U /
         (LIBCRUX_ML_KEM_CONSTANTS_COEFFICIENTS_IN_RING_ELEMENT * (size_t)10U / (size_t)8U);
     i++)
   {

--- a/out/test-libcrux/libcrux_mlkem_avx2.c
+++ b/out/test-libcrux/libcrux_mlkem_avx2.c
@@ -2300,32 +2300,6 @@ static KRML_MUSTINLINE Eurydice_arr_9d sample_from_xof_6c1(const Eurydice_arr_c3
 }
 
 /**
-A monomorphic instance of Eurydice.dst_ref_shared
-with types libcrux_ml_kem_polynomial_PolynomialRingElement_f6, size_t
-
-*/
-typedef struct dst_ref_shared_fb_s
-{
-  const Eurydice_arr_51 *ptr;
-  size_t meta;
-}
-dst_ref_shared_fb;
-
-/**
-A monomorphic instance of Eurydice.array_to_slice_shared
-with types libcrux_ml_kem_polynomial_PolynomialRingElement libcrux_ml_kem_vector_avx2_SIMD256Vector
-with const generics
-- N= 3
-*/
-static dst_ref_shared_fb array_to_slice_shared_cf3(const Eurydice_arr_9d *a)
-{
-  dst_ref_shared_fb lit;
-  lit.ptr = a->data;
-  lit.meta = (size_t)3U;
-  return lit;
-}
-
-/**
 A monomorphic instance of libcrux_ml_kem.matrix.sample_matrix_A
 with types libcrux_ml_kem_vector_avx2_SIMD256Vector, libcrux_ml_kem_hash_functions_avx2_Simd256Hash
 with const generics
@@ -2359,8 +2333,10 @@ sample_matrix_A_6c1(Eurydice_arr_7d *A_transpose, const Eurydice_arr_48 *seed, b
       seeds.data[j].data[32U] = (uint8_t)i1;
       seeds.data[j].data[33U] = (uint8_t)j;);
     Eurydice_arr_9d sampled = sample_from_xof_6c1(&seeds);
-    for (size_t i = (size_t)0U; i < array_to_slice_shared_cf3(&sampled).meta; i++)
-    {
+    KRML_MAYBE_FOR3(i,
+      (size_t)0U,
+      (size_t)3U,
+      (size_t)1U,
       size_t j = i;
       Eurydice_arr_51 sample = sampled.data[j];
       if (transpose)
@@ -2370,8 +2346,7 @@ sample_matrix_A_6c1(Eurydice_arr_7d *A_transpose, const Eurydice_arr_48 *seed, b
       else
       {
         A_transpose->data[i1].data[j] = sample;
-      }
-    });
+      }););
 }
 
 /**
@@ -2558,8 +2533,10 @@ with const generics
 static KRML_MUSTINLINE void
 serialize_vector_ab(const Eurydice_arr_9d *key, Eurydice_mut_borrow_slice_u8 out)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_shared_cf3(key).meta; i++)
-  {
+  KRML_MAYBE_FOR3(i,
+    (size_t)0U,
+    (size_t)3U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_51 re = key->data[i0];
     Eurydice_mut_borrow_slice_u8
@@ -2573,8 +2550,7 @@ serialize_vector_ab(const Eurydice_arr_9d *key, Eurydice_mut_borrow_slice_u8 out
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_arr_cc lvalue = serialize_uncompressed_ring_element_84(&re);
-    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_fe(&lvalue), uint8_t);
-  }
+    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_fe(&lvalue), uint8_t););
 }
 
 /**
@@ -2928,8 +2904,10 @@ sample_matrix_A_b31(Eurydice_arr_7d *A_transpose, const Eurydice_arr_48 *seed, b
       seeds.data[j].data[32U] = (uint8_t)i1;
       seeds.data[j].data[33U] = (uint8_t)j;);
     Eurydice_arr_9d sampled = sample_from_xof_b31(&seeds);
-    for (size_t i = (size_t)0U; i < array_to_slice_shared_cf3(&sampled).meta; i++)
-    {
+    KRML_MAYBE_FOR3(i,
+      (size_t)0U,
+      (size_t)3U,
+      (size_t)1U,
       size_t j = i;
       Eurydice_arr_51 sample = sampled.data[j];
       if (transpose)
@@ -2939,8 +2917,7 @@ sample_matrix_A_b31(Eurydice_arr_7d *A_transpose, const Eurydice_arr_48 *seed, b
       else
       {
         A_transpose->data[i1].data[j] = sample;
-      }
-    });
+      }););
 }
 
 /**
@@ -3581,32 +3558,6 @@ static Eurydice_arr_51 call_mut_73_221(void **_)
 }
 
 /**
-A monomorphic instance of Eurydice.dst_ref_shared
-with types Eurydice_arr_9d, size_t
-
-*/
-typedef struct dst_ref_shared_c8_s
-{
-  const Eurydice_arr_9d *ptr;
-  size_t meta;
-}
-dst_ref_shared_c8;
-
-/**
-A monomorphic instance of Eurydice.array_to_slice_shared
-with types Eurydice_arr libcrux_ml_kem_polynomial_PolynomialRingElement libcrux_ml_kem_vector_avx2_SIMD256Vector[[$3size_t]]
-with const generics
-- N= 3
-*/
-static dst_ref_shared_c8 array_to_slice_shared_b50(const Eurydice_arr_7d *a)
-{
-  dst_ref_shared_c8 lit;
-  lit.ptr = a->data;
-  lit.meta = (size_t)3U;
-  return lit;
-}
-
-/**
  Given two `KyberPolynomialRingElement`s in their NTT representations,
  compute their product. Given two polynomials in the NTT domain `f^` and `ĵ`,
  the `iᵗʰ` coefficient of the product `k̂` is determined by the calculation:
@@ -3673,32 +3624,6 @@ ntt_multiply_d6_84(const Eurydice_arr_51 *self, const Eurydice_arr_51 *rhs)
 }
 
 /**
-A monomorphic instance of Eurydice.dst_ref_shared
-with types libcrux_ml_kem_vector_avx2_SIMD256Vector, size_t
-
-*/
-typedef struct dst_ref_shared_4b_s
-{
-  const __m256i *ptr;
-  size_t meta;
-}
-dst_ref_shared_4b;
-
-/**
-A monomorphic instance of Eurydice.array_to_slice_shared
-with types libcrux_ml_kem_vector_avx2_SIMD256Vector
-with const generics
-- N= 16
-*/
-static dst_ref_shared_4b array_to_slice_shared_85(const Eurydice_arr_51 *a)
-{
-  dst_ref_shared_4b lit;
-  lit.ptr = a->data;
-  lit.meta = (size_t)16U;
-  return lit;
-}
-
-/**
  Given two polynomial ring elements `lhs` and `rhs`, compute the pointwise
  sum of their constituent coefficients.
 */
@@ -3711,11 +3636,12 @@ with const generics
 static KRML_MUSTINLINE void
 add_to_ring_element_ab(Eurydice_arr_51 *myself, const Eurydice_arr_51 *rhs)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_shared_85(&myself[0U]).meta; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (size_t)0U,
+    (size_t)16U,
+    (size_t)1U,
     size_t i0 = i;
-    myself->data[i0] = libcrux_ml_kem_vector_avx2_add_f5(myself->data[i0], &rhs->data[i0]);
-  }
+    myself->data[i0] = libcrux_ml_kem_vector_avx2_add_f5(myself->data[i0], &rhs->data[i0]););
 }
 
 /**
@@ -3797,21 +3723,23 @@ compute_As_plus_e_ab(
   const Eurydice_arr_9d *error_as_ntt
 )
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_shared_b50(matrix_A).meta; i++)
-  {
+  KRML_MAYBE_FOR3(i,
+    (size_t)0U,
+    (size_t)3U,
+    (size_t)1U,
     size_t i0 = i;
     const Eurydice_arr_9d *row = &matrix_A->data[i0];
     Eurydice_arr_51 uu____0 = ZERO_d6_84();
     t_as_ntt->data[i0] = uu____0;
-    for (size_t i1 = (size_t)0U; i1 < array_to_slice_shared_cf3(row).meta; i1++)
-    {
+    KRML_MAYBE_FOR3(i1,
+      (size_t)0U,
+      (size_t)3U,
+      (size_t)1U,
       size_t j = i1;
       const Eurydice_arr_51 *matrix_element = &row->data[j];
       Eurydice_arr_51 product = ntt_multiply_d6_84(matrix_element, &s_as_ntt->data[j]);
-      add_to_ring_element_d6_ab(&t_as_ntt->data[i0], &product);
-    }
-    add_standard_error_reduce_d6_84(&t_as_ntt->data[i0], &error_as_ntt->data[i0]);
-  }
+      add_to_ring_element_d6_ab(&t_as_ntt->data[i0], &product););
+    add_standard_error_reduce_d6_84(&t_as_ntt->data[i0], &error_as_ntt->data[i0]););
 }
 
 /**
@@ -4393,20 +4321,22 @@ compute_vector_u_ab(
     void *lvalue = (void *)0U;
     arr_struct.data[i] = call_mut_a8_ab(&lvalue););
   Eurydice_arr_9d result = arr_struct;
-  for (size_t i0 = (size_t)0U; i0 < array_to_slice_shared_b50(a_as_ntt).meta; i0++)
-  {
+  KRML_MAYBE_FOR3(i0,
+    (size_t)0U,
+    (size_t)3U,
+    (size_t)1U,
     size_t i1 = i0;
     const Eurydice_arr_9d *row = &a_as_ntt->data[i1];
-    for (size_t i = (size_t)0U; i < array_to_slice_shared_cf3(row).meta; i++)
-    {
+    KRML_MAYBE_FOR3(i,
+      (size_t)0U,
+      (size_t)3U,
+      (size_t)1U,
       size_t j = i;
       const Eurydice_arr_51 *a_element = &row->data[j];
       Eurydice_arr_51 product = ntt_multiply_d6_84(a_element, &r_as_ntt->data[j]);
-      add_to_ring_element_d6_ab(&result.data[i1], &product);
-    }
+      add_to_ring_element_d6_ab(&result.data[i1], &product););
     invert_ntt_montgomery_ab(&result.data[i1]);
-    add_error_reduce_d6_84(&result.data[i1], &error_1->data[i1]);
-  }
+    add_error_reduce_d6_84(&result.data[i1], &error_1->data[i1]););
   return result;
 }
 
@@ -4587,8 +4517,10 @@ with const generics
 static KRML_MUSTINLINE void
 compress_then_serialize_u_8c(Eurydice_arr_9d input, Eurydice_mut_borrow_slice_u8 out)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_shared_cf3(&input).meta; i++)
-  {
+  KRML_MAYBE_FOR3(i,
+    (size_t)0U,
+    (size_t)3U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_51 re = input.data[i0];
     Eurydice_mut_borrow_slice_u8
@@ -4602,8 +4534,7 @@ compress_then_serialize_u_8c(Eurydice_arr_9d input, Eurydice_mut_borrow_slice_u8
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_arr_b7 lvalue = compress_then_serialize_ring_element_u_a4(&re);
-    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_d3(&lvalue), uint8_t);
-  }
+    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_d3(&lvalue), uint8_t););
 }
 
 /**
@@ -5321,7 +5252,7 @@ deserialize_then_decompress_u_ed(const Eurydice_arr_2c *ciphertext)
   (size_t
     i = (size_t)0U;
     i <
-      Eurydice_array_to_slice_shared_42(ciphertext).meta /
+      (size_t)1088U /
         (LIBCRUX_ML_KEM_CONSTANTS_COEFFICIENTS_IN_RING_ELEMENT * (size_t)10U / (size_t)8U);
     i++)
   {
@@ -6695,20 +6626,6 @@ static KRML_MUSTINLINE Eurydice_arr_c5 sample_from_xof_6c0(const Eurydice_arr_c5
 }
 
 /**
-A monomorphic instance of Eurydice.array_to_slice_shared
-with types libcrux_ml_kem_polynomial_PolynomialRingElement libcrux_ml_kem_vector_avx2_SIMD256Vector
-with const generics
-- N= 4
-*/
-static dst_ref_shared_fb array_to_slice_shared_cf2(const Eurydice_arr_c5 *a)
-{
-  dst_ref_shared_fb lit;
-  lit.ptr = a->data;
-  lit.meta = (size_t)4U;
-  return lit;
-}
-
-/**
 A monomorphic instance of libcrux_ml_kem.matrix.sample_matrix_A
 with types libcrux_ml_kem_vector_avx2_SIMD256Vector, libcrux_ml_kem_hash_functions_avx2_Simd256Hash
 with const generics
@@ -6742,8 +6659,10 @@ sample_matrix_A_6c0(Eurydice_arr_43 *A_transpose, const Eurydice_arr_48 *seed, b
       seeds.data[j].data[32U] = (uint8_t)i1;
       seeds.data[j].data[33U] = (uint8_t)j;);
     Eurydice_arr_c5 sampled = sample_from_xof_6c0(&seeds);
-    for (size_t i = (size_t)0U; i < array_to_slice_shared_cf2(&sampled).meta; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (size_t)0U,
+      (size_t)4U,
+      (size_t)1U,
       size_t j = i;
       Eurydice_arr_51 sample = sampled.data[j];
       if (transpose)
@@ -6753,8 +6672,7 @@ sample_matrix_A_6c0(Eurydice_arr_43 *A_transpose, const Eurydice_arr_48 *seed, b
       else
       {
         A_transpose->data[i1].data[j] = sample;
-      }
-    });
+      }););
 }
 
 /**
@@ -6819,8 +6737,10 @@ with const generics
 static KRML_MUSTINLINE void
 serialize_vector_42(const Eurydice_arr_c5 *key, Eurydice_mut_borrow_slice_u8 out)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_shared_cf2(key).meta; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (size_t)0U,
+    (size_t)4U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_51 re = key->data[i0];
     Eurydice_mut_borrow_slice_u8
@@ -6834,8 +6754,7 @@ serialize_vector_42(const Eurydice_arr_c5 *key, Eurydice_mut_borrow_slice_u8 out
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_arr_cc lvalue = serialize_uncompressed_ring_element_84(&re);
-    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_fe(&lvalue), uint8_t);
-  }
+    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_fe(&lvalue), uint8_t););
 }
 
 /**
@@ -7163,8 +7082,10 @@ sample_matrix_A_b30(Eurydice_arr_43 *A_transpose, const Eurydice_arr_48 *seed, b
       seeds.data[j].data[32U] = (uint8_t)i1;
       seeds.data[j].data[33U] = (uint8_t)j;);
     Eurydice_arr_c5 sampled = sample_from_xof_b30(&seeds);
-    for (size_t i = (size_t)0U; i < array_to_slice_shared_cf2(&sampled).meta; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (size_t)0U,
+      (size_t)4U,
+      (size_t)1U,
       size_t j = i;
       Eurydice_arr_51 sample = sampled.data[j];
       if (transpose)
@@ -7174,8 +7095,7 @@ sample_matrix_A_b30(Eurydice_arr_43 *A_transpose, const Eurydice_arr_48 *seed, b
       else
       {
         A_transpose->data[i1].data[j] = sample;
-      }
-    });
+      }););
 }
 
 /**
@@ -7484,32 +7404,6 @@ static Eurydice_arr_51 call_mut_73_220(void **_)
 }
 
 /**
-A monomorphic instance of Eurydice.dst_ref_shared
-with types Eurydice_arr_c5, size_t
-
-*/
-typedef struct dst_ref_shared_df_s
-{
-  const Eurydice_arr_c5 *ptr;
-  size_t meta;
-}
-dst_ref_shared_df;
-
-/**
-A monomorphic instance of Eurydice.array_to_slice_shared
-with types Eurydice_arr libcrux_ml_kem_polynomial_PolynomialRingElement libcrux_ml_kem_vector_avx2_SIMD256Vector[[$4size_t]]
-with const generics
-- N= 4
-*/
-static dst_ref_shared_df array_to_slice_shared_7c(const Eurydice_arr_43 *a)
-{
-  dst_ref_shared_df lit;
-  lit.ptr = a->data;
-  lit.meta = (size_t)4U;
-  return lit;
-}
-
-/**
  Given two polynomial ring elements `lhs` and `rhs`, compute the pointwise
  sum of their constituent coefficients.
 */
@@ -7522,11 +7416,12 @@ with const generics
 static KRML_MUSTINLINE void
 add_to_ring_element_42(Eurydice_arr_51 *myself, const Eurydice_arr_51 *rhs)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_shared_85(&myself[0U]).meta; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (size_t)0U,
+    (size_t)16U,
+    (size_t)1U,
     size_t i0 = i;
-    myself->data[i0] = libcrux_ml_kem_vector_avx2_add_f5(myself->data[i0], &rhs->data[i0]);
-  }
+    myself->data[i0] = libcrux_ml_kem_vector_avx2_add_f5(myself->data[i0], &rhs->data[i0]););
 }
 
 /**
@@ -7561,21 +7456,23 @@ compute_As_plus_e_42(
   const Eurydice_arr_c5 *error_as_ntt
 )
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_shared_7c(matrix_A).meta; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (size_t)0U,
+    (size_t)4U,
+    (size_t)1U,
     size_t i0 = i;
     const Eurydice_arr_c5 *row = &matrix_A->data[i0];
     Eurydice_arr_51 uu____0 = ZERO_d6_84();
     t_as_ntt->data[i0] = uu____0;
-    for (size_t i1 = (size_t)0U; i1 < array_to_slice_shared_cf2(row).meta; i1++)
-    {
+    KRML_MAYBE_FOR4(i1,
+      (size_t)0U,
+      (size_t)4U,
+      (size_t)1U,
       size_t j = i1;
       const Eurydice_arr_51 *matrix_element = &row->data[j];
       Eurydice_arr_51 product = ntt_multiply_d6_84(matrix_element, &s_as_ntt->data[j]);
-      add_to_ring_element_d6_42(&t_as_ntt->data[i0], &product);
-    }
-    add_standard_error_reduce_d6_84(&t_as_ntt->data[i0], &error_as_ntt->data[i0]);
-  }
+      add_to_ring_element_d6_42(&t_as_ntt->data[i0], &product););
+    add_standard_error_reduce_d6_84(&t_as_ntt->data[i0], &error_as_ntt->data[i0]););
 }
 
 /**
@@ -7979,20 +7876,22 @@ compute_vector_u_42(
     void *lvalue = (void *)0U;
     arr_struct.data[i] = call_mut_a8_42(&lvalue););
   Eurydice_arr_c5 result = arr_struct;
-  for (size_t i0 = (size_t)0U; i0 < array_to_slice_shared_7c(a_as_ntt).meta; i0++)
-  {
+  KRML_MAYBE_FOR4(i0,
+    (size_t)0U,
+    (size_t)4U,
+    (size_t)1U,
     size_t i1 = i0;
     const Eurydice_arr_c5 *row = &a_as_ntt->data[i1];
-    for (size_t i = (size_t)0U; i < array_to_slice_shared_cf2(row).meta; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (size_t)0U,
+      (size_t)4U,
+      (size_t)1U,
       size_t j = i;
       const Eurydice_arr_51 *a_element = &row->data[j];
       Eurydice_arr_51 product = ntt_multiply_d6_84(a_element, &r_as_ntt->data[j]);
-      add_to_ring_element_d6_42(&result.data[i1], &product);
-    }
+      add_to_ring_element_d6_42(&result.data[i1], &product););
     invert_ntt_montgomery_42(&result.data[i1]);
-    add_error_reduce_d6_84(&result.data[i1], &error_1->data[i1]);
-  }
+    add_error_reduce_d6_84(&result.data[i1], &error_1->data[i1]););
   return result;
 }
 
@@ -8054,8 +7953,10 @@ with const generics
 static KRML_MUSTINLINE void
 compress_then_serialize_u_c9(Eurydice_arr_c5 input, Eurydice_mut_borrow_slice_u8 out)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_shared_cf2(&input).meta; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (size_t)0U,
+    (size_t)4U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_51 re = input.data[i0];
     Eurydice_mut_borrow_slice_u8
@@ -8069,8 +7970,7 @@ compress_then_serialize_u_c9(Eurydice_arr_c5 input, Eurydice_mut_borrow_slice_u8
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_arr_790 lvalue = compress_then_serialize_ring_element_u_6f(&re);
-    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_89(&lvalue), uint8_t);
-  }
+    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_89(&lvalue), uint8_t););
 }
 
 /**
@@ -8401,7 +8301,7 @@ deserialize_then_decompress_u_1e(const Eurydice_arr_00 *ciphertext)
   (size_t
     i = (size_t)0U;
     i <
-      Eurydice_array_to_slice_shared_4e(ciphertext).meta /
+      (size_t)1568U /
         (LIBCRUX_ML_KEM_CONSTANTS_COEFFICIENTS_IN_RING_ELEMENT * (size_t)11U / (size_t)8U);
     i++)
   {
@@ -9551,20 +9451,6 @@ static KRML_MUSTINLINE Eurydice_arr_d3 sample_from_xof_6c(const Eurydice_arr_f9 
 }
 
 /**
-A monomorphic instance of Eurydice.array_to_slice_shared
-with types libcrux_ml_kem_polynomial_PolynomialRingElement libcrux_ml_kem_vector_avx2_SIMD256Vector
-with const generics
-- N= 2
-*/
-static dst_ref_shared_fb array_to_slice_shared_cf(const Eurydice_arr_d3 *a)
-{
-  dst_ref_shared_fb lit;
-  lit.ptr = a->data;
-  lit.meta = (size_t)2U;
-  return lit;
-}
-
-/**
 A monomorphic instance of libcrux_ml_kem.matrix.sample_matrix_A
 with types libcrux_ml_kem_vector_avx2_SIMD256Vector, libcrux_ml_kem_hash_functions_avx2_Simd256Hash
 with const generics
@@ -9598,8 +9484,10 @@ sample_matrix_A_6c(Eurydice_arr_9a *A_transpose, const Eurydice_arr_48 *seed, bo
       seeds.data[j].data[32U] = (uint8_t)i1;
       seeds.data[j].data[33U] = (uint8_t)j;);
     Eurydice_arr_d3 sampled = sample_from_xof_6c(&seeds);
-    for (size_t i = (size_t)0U; i < array_to_slice_shared_cf(&sampled).meta; i++)
-    {
+    KRML_MAYBE_FOR2(i,
+      (size_t)0U,
+      (size_t)2U,
+      (size_t)1U,
       size_t j = i;
       Eurydice_arr_51 sample = sampled.data[j];
       if (transpose)
@@ -9609,8 +9497,7 @@ sample_matrix_A_6c(Eurydice_arr_9a *A_transpose, const Eurydice_arr_48 *seed, bo
       else
       {
         A_transpose->data[i1].data[j] = sample;
-      }
-    });
+      }););
 }
 
 /**
@@ -9675,8 +9562,10 @@ with const generics
 static KRML_MUSTINLINE void
 serialize_vector_89(const Eurydice_arr_d3 *key, Eurydice_mut_borrow_slice_u8 out)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_shared_cf(key).meta; i++)
-  {
+  KRML_MAYBE_FOR2(i,
+    (size_t)0U,
+    (size_t)2U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_51 re = key->data[i0];
     Eurydice_mut_borrow_slice_u8
@@ -9690,8 +9579,7 @@ serialize_vector_89(const Eurydice_arr_d3 *key, Eurydice_mut_borrow_slice_u8 out
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_arr_cc lvalue = serialize_uncompressed_ring_element_84(&re);
-    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_fe(&lvalue), uint8_t);
-  }
+    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_fe(&lvalue), uint8_t););
 }
 
 /**
@@ -10017,8 +9905,10 @@ sample_matrix_A_b3(Eurydice_arr_9a *A_transpose, const Eurydice_arr_48 *seed, bo
       seeds.data[j].data[32U] = (uint8_t)i1;
       seeds.data[j].data[33U] = (uint8_t)j;);
     Eurydice_arr_d3 sampled = sample_from_xof_b3(&seeds);
-    for (size_t i = (size_t)0U; i < array_to_slice_shared_cf(&sampled).meta; i++)
-    {
+    KRML_MAYBE_FOR2(i,
+      (size_t)0U,
+      (size_t)2U,
+      (size_t)1U,
       size_t j = i;
       Eurydice_arr_51 sample = sampled.data[j];
       if (transpose)
@@ -10028,8 +9918,7 @@ sample_matrix_A_b3(Eurydice_arr_9a *A_transpose, const Eurydice_arr_48 *seed, bo
       else
       {
         A_transpose->data[i1].data[j] = sample;
-      }
-    });
+      }););
 }
 
 /**
@@ -10345,32 +10234,6 @@ static Eurydice_arr_51 call_mut_73_22(void **_)
 }
 
 /**
-A monomorphic instance of Eurydice.dst_ref_shared
-with types Eurydice_arr_d3, size_t
-
-*/
-typedef struct dst_ref_shared_08_s
-{
-  const Eurydice_arr_d3 *ptr;
-  size_t meta;
-}
-dst_ref_shared_08;
-
-/**
-A monomorphic instance of Eurydice.array_to_slice_shared
-with types Eurydice_arr libcrux_ml_kem_polynomial_PolynomialRingElement libcrux_ml_kem_vector_avx2_SIMD256Vector[[$2size_t]]
-with const generics
-- N= 2
-*/
-static dst_ref_shared_08 array_to_slice_shared_f4(const Eurydice_arr_9a *a)
-{
-  dst_ref_shared_08 lit;
-  lit.ptr = a->data;
-  lit.meta = (size_t)2U;
-  return lit;
-}
-
-/**
  Given two polynomial ring elements `lhs` and `rhs`, compute the pointwise
  sum of their constituent coefficients.
 */
@@ -10383,11 +10246,12 @@ with const generics
 static KRML_MUSTINLINE void
 add_to_ring_element_89(Eurydice_arr_51 *myself, const Eurydice_arr_51 *rhs)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_shared_85(&myself[0U]).meta; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (size_t)0U,
+    (size_t)16U,
+    (size_t)1U,
     size_t i0 = i;
-    myself->data[i0] = libcrux_ml_kem_vector_avx2_add_f5(myself->data[i0], &rhs->data[i0]);
-  }
+    myself->data[i0] = libcrux_ml_kem_vector_avx2_add_f5(myself->data[i0], &rhs->data[i0]););
 }
 
 /**
@@ -10422,21 +10286,23 @@ compute_As_plus_e_89(
   const Eurydice_arr_d3 *error_as_ntt
 )
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_shared_f4(matrix_A).meta; i++)
-  {
+  KRML_MAYBE_FOR2(i,
+    (size_t)0U,
+    (size_t)2U,
+    (size_t)1U,
     size_t i0 = i;
     const Eurydice_arr_d3 *row = &matrix_A->data[i0];
     Eurydice_arr_51 uu____0 = ZERO_d6_84();
     t_as_ntt->data[i0] = uu____0;
-    for (size_t i1 = (size_t)0U; i1 < array_to_slice_shared_cf(row).meta; i1++)
-    {
+    KRML_MAYBE_FOR2(i1,
+      (size_t)0U,
+      (size_t)2U,
+      (size_t)1U,
       size_t j = i1;
       const Eurydice_arr_51 *matrix_element = &row->data[j];
       Eurydice_arr_51 product = ntt_multiply_d6_84(matrix_element, &s_as_ntt->data[j]);
-      add_to_ring_element_d6_89(&t_as_ntt->data[i0], &product);
-    }
-    add_standard_error_reduce_d6_84(&t_as_ntt->data[i0], &error_as_ntt->data[i0]);
-  }
+      add_to_ring_element_d6_89(&t_as_ntt->data[i0], &product););
+    add_standard_error_reduce_d6_84(&t_as_ntt->data[i0], &error_as_ntt->data[i0]););
 }
 
 /**
@@ -10880,20 +10746,22 @@ compute_vector_u_89(
     void *lvalue = (void *)0U;
     arr_struct.data[i] = call_mut_a8_89(&lvalue););
   Eurydice_arr_d3 result = arr_struct;
-  for (size_t i0 = (size_t)0U; i0 < array_to_slice_shared_f4(a_as_ntt).meta; i0++)
-  {
+  KRML_MAYBE_FOR2(i0,
+    (size_t)0U,
+    (size_t)2U,
+    (size_t)1U,
     size_t i1 = i0;
     const Eurydice_arr_d3 *row = &a_as_ntt->data[i1];
-    for (size_t i = (size_t)0U; i < array_to_slice_shared_cf(row).meta; i++)
-    {
+    KRML_MAYBE_FOR2(i,
+      (size_t)0U,
+      (size_t)2U,
+      (size_t)1U,
       size_t j = i;
       const Eurydice_arr_51 *a_element = &row->data[j];
       Eurydice_arr_51 product = ntt_multiply_d6_84(a_element, &r_as_ntt->data[j]);
-      add_to_ring_element_d6_89(&result.data[i1], &product);
-    }
+      add_to_ring_element_d6_89(&result.data[i1], &product););
     invert_ntt_montgomery_89(&result.data[i1]);
-    add_error_reduce_d6_84(&result.data[i1], &error_1->data[i1]);
-  }
+    add_error_reduce_d6_84(&result.data[i1], &error_1->data[i1]););
   return result;
 }
 
@@ -10912,8 +10780,10 @@ with const generics
 static KRML_MUSTINLINE void
 compress_then_serialize_u_2d(Eurydice_arr_d3 input, Eurydice_mut_borrow_slice_u8 out)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_shared_cf(&input).meta; i++)
-  {
+  KRML_MAYBE_FOR2(i,
+    (size_t)0U,
+    (size_t)2U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_51 re = input.data[i0];
     Eurydice_mut_borrow_slice_u8
@@ -10927,8 +10797,7 @@ compress_then_serialize_u_2d(Eurydice_arr_d3 input, Eurydice_mut_borrow_slice_u8
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_arr_b7 lvalue = compress_then_serialize_ring_element_u_a4(&re);
-    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_d3(&lvalue), uint8_t);
-  }
+    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_d3(&lvalue), uint8_t););
 }
 
 /**
@@ -11224,7 +11093,7 @@ deserialize_then_decompress_u_ba(const Eurydice_arr_56 *ciphertext)
   (size_t
     i = (size_t)0U;
     i <
-      Eurydice_array_to_slice_shared_ee(ciphertext).meta /
+      (size_t)768U /
         (LIBCRUX_ML_KEM_CONSTANTS_COEFFICIENTS_IN_RING_ELEMENT * (size_t)10U / (size_t)8U);
     i++)
   {

--- a/out/test-libcrux/libcrux_mlkem_portable.c
+++ b/out/test-libcrux/libcrux_mlkem_portable.c
@@ -2240,32 +2240,6 @@ static KRML_MUSTINLINE Eurydice_arr_cf sample_from_xof_2b1(const Eurydice_arr_c5
 }
 
 /**
-A monomorphic instance of Eurydice.dst_ref_shared
-with types libcrux_ml_kem_polynomial_PolynomialRingElement_1d, size_t
-
-*/
-typedef struct dst_ref_shared_b0_s
-{
-  const Eurydice_arr_b9 *ptr;
-  size_t meta;
-}
-dst_ref_shared_b0;
-
-/**
-A monomorphic instance of Eurydice.array_to_slice_shared
-with types libcrux_ml_kem_polynomial_PolynomialRingElement libcrux_ml_kem_vector_portable_vector_type_PortableVector
-with const generics
-- N= 4
-*/
-static dst_ref_shared_b0 array_to_slice_shared_cf4(const Eurydice_arr_cf *a)
-{
-  dst_ref_shared_b0 lit;
-  lit.ptr = a->data;
-  lit.meta = (size_t)4U;
-  return lit;
-}
-
-/**
 A monomorphic instance of libcrux_ml_kem.matrix.sample_matrix_A
 with types libcrux_ml_kem_vector_portable_vector_type_PortableVector, libcrux_ml_kem_hash_functions_portable_PortableHash[[$4size_t]]
 with const generics
@@ -2299,8 +2273,10 @@ sample_matrix_A_2b1(Eurydice_arr_5c *A_transpose, const Eurydice_arr_48 *seed, b
       seeds.data[j].data[32U] = (uint8_t)i1;
       seeds.data[j].data[33U] = (uint8_t)j;);
     Eurydice_arr_cf sampled = sample_from_xof_2b1(&seeds);
-    for (size_t i = (size_t)0U; i < array_to_slice_shared_cf4(&sampled).meta; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (size_t)0U,
+      (size_t)4U,
+      (size_t)1U,
       size_t j = i;
       Eurydice_arr_b9 sample = sampled.data[j];
       if (transpose)
@@ -2310,8 +2286,7 @@ sample_matrix_A_2b1(Eurydice_arr_5c *A_transpose, const Eurydice_arr_48 *seed, b
       else
       {
         A_transpose->data[i1].data[j] = sample;
-      }
-    });
+      }););
 }
 
 /**
@@ -2415,8 +2390,10 @@ with const generics
 static KRML_MUSTINLINE void
 serialize_vector_d0(const Eurydice_arr_cf *key, Eurydice_mut_borrow_slice_u8 out)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_shared_cf4(key).meta; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (size_t)0U,
+    (size_t)4U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_b9 re = key->data[i0];
     Eurydice_mut_borrow_slice_u8
@@ -2430,8 +2407,7 @@ serialize_vector_d0(const Eurydice_arr_cf *key, Eurydice_mut_borrow_slice_u8 out
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_arr_cc lvalue = serialize_uncompressed_ring_element_ea(&re);
-    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_fe(&lvalue), uint8_t);
-  }
+    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_fe(&lvalue), uint8_t););
 }
 
 /**
@@ -3394,32 +3370,6 @@ static Eurydice_arr_b9 call_mut_73_1c1(void **_)
 }
 
 /**
-A monomorphic instance of Eurydice.dst_ref_shared
-with types Eurydice_arr_cf, size_t
-
-*/
-typedef struct dst_ref_shared_16_s
-{
-  const Eurydice_arr_cf *ptr;
-  size_t meta;
-}
-dst_ref_shared_16;
-
-/**
-A monomorphic instance of Eurydice.array_to_slice_shared
-with types Eurydice_arr libcrux_ml_kem_polynomial_PolynomialRingElement libcrux_ml_kem_vector_portable_vector_type_PortableVector[[$4size_t]]
-with const generics
-- N= 4
-*/
-static dst_ref_shared_16 array_to_slice_shared_7c0(const Eurydice_arr_5c *a)
-{
-  dst_ref_shared_16 lit;
-  lit.ptr = a->data;
-  lit.meta = (size_t)4U;
-  return lit;
-}
-
-/**
  Given two `KyberPolynomialRingElement`s in their NTT representations,
  compute their product. Given two polynomials in the NTT domain `f^` and `ĵ`,
  the `iᵗʰ` coefficient of the product `k̂` is determined by the calculation:
@@ -3488,32 +3438,6 @@ ntt_multiply_d6_ea(const Eurydice_arr_b9 *self, const Eurydice_arr_b9 *rhs)
 }
 
 /**
-A monomorphic instance of Eurydice.dst_ref_shared
-with types libcrux_ml_kem_vector_portable_vector_type_PortableVector, size_t
-
-*/
-typedef struct dst_ref_shared_f3_s
-{
-  const Eurydice_arr_e2 *ptr;
-  size_t meta;
-}
-dst_ref_shared_f3;
-
-/**
-A monomorphic instance of Eurydice.array_to_slice_shared
-with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
-with const generics
-- N= 16
-*/
-static dst_ref_shared_f3 array_to_slice_shared_24(const Eurydice_arr_b9 *a)
-{
-  dst_ref_shared_f3 lit;
-  lit.ptr = a->data;
-  lit.meta = (size_t)16U;
-  return lit;
-}
-
-/**
  Given two polynomial ring elements `lhs` and `rhs`, compute the pointwise
  sum of their constituent coefficients.
 */
@@ -3526,13 +3450,14 @@ with const generics
 static KRML_MUSTINLINE void
 add_to_ring_element_d0(Eurydice_arr_b9 *myself, const Eurydice_arr_b9 *rhs)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_shared_24(&myself[0U]).meta; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (size_t)0U,
+    (size_t)16U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_e2
     uu____0 = libcrux_ml_kem_vector_portable_add_b8(myself->data[i0], &rhs->data[i0]);
-    myself->data[i0] = uu____0;
-  }
+    myself->data[i0] = uu____0;);
 }
 
 /**
@@ -3615,21 +3540,23 @@ compute_As_plus_e_d0(
   const Eurydice_arr_cf *error_as_ntt
 )
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_shared_7c0(matrix_A).meta; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (size_t)0U,
+    (size_t)4U,
+    (size_t)1U,
     size_t i0 = i;
     const Eurydice_arr_cf *row = &matrix_A->data[i0];
     Eurydice_arr_b9 uu____0 = ZERO_d6_ea();
     t_as_ntt->data[i0] = uu____0;
-    for (size_t i1 = (size_t)0U; i1 < array_to_slice_shared_cf4(row).meta; i1++)
-    {
+    KRML_MAYBE_FOR4(i1,
+      (size_t)0U,
+      (size_t)4U,
+      (size_t)1U,
       size_t j = i1;
       const Eurydice_arr_b9 *matrix_element = &row->data[j];
       Eurydice_arr_b9 product = ntt_multiply_d6_ea(matrix_element, &s_as_ntt->data[j]);
-      add_to_ring_element_d6_d0(&t_as_ntt->data[i0], &product);
-    }
-    add_standard_error_reduce_d6_ea(&t_as_ntt->data[i0], &error_as_ntt->data[i0]);
-  }
+      add_to_ring_element_d6_d0(&t_as_ntt->data[i0], &product););
+    add_standard_error_reduce_d6_ea(&t_as_ntt->data[i0], &error_as_ntt->data[i0]););
 }
 
 /**
@@ -4221,20 +4148,22 @@ compute_vector_u_d0(
     void *lvalue = (void *)0U;
     arr_struct.data[i] = call_mut_a8_d0(&lvalue););
   Eurydice_arr_cf result = arr_struct;
-  for (size_t i0 = (size_t)0U; i0 < array_to_slice_shared_7c0(a_as_ntt).meta; i0++)
-  {
+  KRML_MAYBE_FOR4(i0,
+    (size_t)0U,
+    (size_t)4U,
+    (size_t)1U,
     size_t i1 = i0;
     const Eurydice_arr_cf *row = &a_as_ntt->data[i1];
-    for (size_t i = (size_t)0U; i < array_to_slice_shared_cf4(row).meta; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (size_t)0U,
+      (size_t)4U,
+      (size_t)1U,
       size_t j = i;
       const Eurydice_arr_b9 *a_element = &row->data[j];
       Eurydice_arr_b9 product = ntt_multiply_d6_ea(a_element, &r_as_ntt->data[j]);
-      add_to_ring_element_d6_d0(&result.data[i1], &product);
-    }
+      add_to_ring_element_d6_d0(&result.data[i1], &product););
     invert_ntt_montgomery_d0(&result.data[i1]);
-    add_error_reduce_d6_ea(&result.data[i1], &error_1->data[i1]);
-  }
+    add_error_reduce_d6_ea(&result.data[i1], &error_1->data[i1]););
   return result;
 }
 
@@ -4360,8 +4289,10 @@ with const generics
 static KRML_MUSTINLINE void
 compress_then_serialize_u_2f(Eurydice_arr_cf input, Eurydice_mut_borrow_slice_u8 out)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_shared_cf4(&input).meta; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (size_t)0U,
+    (size_t)4U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_b9 re = input.data[i0];
     Eurydice_mut_borrow_slice_u8
@@ -4375,8 +4306,7 @@ compress_then_serialize_u_2f(Eurydice_arr_cf input, Eurydice_mut_borrow_slice_u8
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_arr_790 lvalue = compress_then_serialize_ring_element_u_82(&re);
-    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_89(&lvalue), uint8_t);
-  }
+    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_89(&lvalue), uint8_t););
 }
 
 /**
@@ -5029,7 +4959,7 @@ deserialize_then_decompress_u_00(const Eurydice_arr_00 *ciphertext)
   (size_t
     i = (size_t)0U;
     i <
-      Eurydice_array_to_slice_shared_4e(ciphertext).meta /
+      (size_t)1568U /
         (LIBCRUX_ML_KEM_CONSTANTS_COEFFICIENTS_IN_RING_ELEMENT * (size_t)11U / (size_t)8U);
     i++)
   {
@@ -6316,20 +6246,6 @@ static KRML_MUSTINLINE Eurydice_arr_3d0 sample_from_xof_2b0(const Eurydice_arr_f
 }
 
 /**
-A monomorphic instance of Eurydice.array_to_slice_shared
-with types libcrux_ml_kem_polynomial_PolynomialRingElement libcrux_ml_kem_vector_portable_vector_type_PortableVector
-with const generics
-- N= 2
-*/
-static dst_ref_shared_b0 array_to_slice_shared_cf1(const Eurydice_arr_3d0 *a)
-{
-  dst_ref_shared_b0 lit;
-  lit.ptr = a->data;
-  lit.meta = (size_t)2U;
-  return lit;
-}
-
-/**
 A monomorphic instance of libcrux_ml_kem.matrix.sample_matrix_A
 with types libcrux_ml_kem_vector_portable_vector_type_PortableVector, libcrux_ml_kem_hash_functions_portable_PortableHash[[$2size_t]]
 with const generics
@@ -6363,8 +6279,10 @@ sample_matrix_A_2b0(Eurydice_arr_6d0 *A_transpose, const Eurydice_arr_48 *seed, 
       seeds.data[j].data[32U] = (uint8_t)i1;
       seeds.data[j].data[33U] = (uint8_t)j;);
     Eurydice_arr_3d0 sampled = sample_from_xof_2b0(&seeds);
-    for (size_t i = (size_t)0U; i < array_to_slice_shared_cf1(&sampled).meta; i++)
-    {
+    KRML_MAYBE_FOR2(i,
+      (size_t)0U,
+      (size_t)2U,
+      (size_t)1U,
       size_t j = i;
       Eurydice_arr_b9 sample = sampled.data[j];
       if (transpose)
@@ -6374,8 +6292,7 @@ sample_matrix_A_2b0(Eurydice_arr_6d0 *A_transpose, const Eurydice_arr_48 *seed, 
       else
       {
         A_transpose->data[i1].data[j] = sample;
-      }
-    });
+      }););
 }
 
 /**
@@ -6440,8 +6357,10 @@ with const generics
 static KRML_MUSTINLINE void
 serialize_vector_a0(const Eurydice_arr_3d0 *key, Eurydice_mut_borrow_slice_u8 out)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_shared_cf1(key).meta; i++)
-  {
+  KRML_MAYBE_FOR2(i,
+    (size_t)0U,
+    (size_t)2U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_b9 re = key->data[i0];
     Eurydice_mut_borrow_slice_u8
@@ -6455,8 +6374,7 @@ serialize_vector_a0(const Eurydice_arr_3d0 *key, Eurydice_mut_borrow_slice_u8 ou
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_arr_cc lvalue = serialize_uncompressed_ring_element_ea(&re);
-    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_fe(&lvalue), uint8_t);
-  }
+    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_fe(&lvalue), uint8_t););
 }
 
 /**
@@ -7056,32 +6974,6 @@ static Eurydice_arr_b9 call_mut_73_1c0(void **_)
 }
 
 /**
-A monomorphic instance of Eurydice.dst_ref_shared
-with types Eurydice_arr_3d0, size_t
-
-*/
-typedef struct dst_ref_shared_d9_s
-{
-  const Eurydice_arr_3d0 *ptr;
-  size_t meta;
-}
-dst_ref_shared_d9;
-
-/**
-A monomorphic instance of Eurydice.array_to_slice_shared
-with types Eurydice_arr libcrux_ml_kem_polynomial_PolynomialRingElement libcrux_ml_kem_vector_portable_vector_type_PortableVector[[$2size_t]]
-with const generics
-- N= 2
-*/
-static dst_ref_shared_d9 array_to_slice_shared_f40(const Eurydice_arr_6d0 *a)
-{
-  dst_ref_shared_d9 lit;
-  lit.ptr = a->data;
-  lit.meta = (size_t)2U;
-  return lit;
-}
-
-/**
  Given two polynomial ring elements `lhs` and `rhs`, compute the pointwise
  sum of their constituent coefficients.
 */
@@ -7094,13 +6986,14 @@ with const generics
 static KRML_MUSTINLINE void
 add_to_ring_element_a0(Eurydice_arr_b9 *myself, const Eurydice_arr_b9 *rhs)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_shared_24(&myself[0U]).meta; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (size_t)0U,
+    (size_t)16U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_e2
     uu____0 = libcrux_ml_kem_vector_portable_add_b8(myself->data[i0], &rhs->data[i0]);
-    myself->data[i0] = uu____0;
-  }
+    myself->data[i0] = uu____0;);
 }
 
 /**
@@ -7135,21 +7028,23 @@ compute_As_plus_e_a0(
   const Eurydice_arr_3d0 *error_as_ntt
 )
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_shared_f40(matrix_A).meta; i++)
-  {
+  KRML_MAYBE_FOR2(i,
+    (size_t)0U,
+    (size_t)2U,
+    (size_t)1U,
     size_t i0 = i;
     const Eurydice_arr_3d0 *row = &matrix_A->data[i0];
     Eurydice_arr_b9 uu____0 = ZERO_d6_ea();
     t_as_ntt->data[i0] = uu____0;
-    for (size_t i1 = (size_t)0U; i1 < array_to_slice_shared_cf1(row).meta; i1++)
-    {
+    KRML_MAYBE_FOR2(i1,
+      (size_t)0U,
+      (size_t)2U,
+      (size_t)1U,
       size_t j = i1;
       const Eurydice_arr_b9 *matrix_element = &row->data[j];
       Eurydice_arr_b9 product = ntt_multiply_d6_ea(matrix_element, &s_as_ntt->data[j]);
-      add_to_ring_element_d6_a0(&t_as_ntt->data[i0], &product);
-    }
-    add_standard_error_reduce_d6_ea(&t_as_ntt->data[i0], &error_as_ntt->data[i0]);
-  }
+      add_to_ring_element_d6_a0(&t_as_ntt->data[i0], &product););
+    add_standard_error_reduce_d6_ea(&t_as_ntt->data[i0], &error_as_ntt->data[i0]););
 }
 
 /**
@@ -7586,20 +7481,22 @@ compute_vector_u_a0(
     void *lvalue = (void *)0U;
     arr_struct.data[i] = call_mut_a8_a0(&lvalue););
   Eurydice_arr_3d0 result = arr_struct;
-  for (size_t i0 = (size_t)0U; i0 < array_to_slice_shared_f40(a_as_ntt).meta; i0++)
-  {
+  KRML_MAYBE_FOR2(i0,
+    (size_t)0U,
+    (size_t)2U,
+    (size_t)1U,
     size_t i1 = i0;
     const Eurydice_arr_3d0 *row = &a_as_ntt->data[i1];
-    for (size_t i = (size_t)0U; i < array_to_slice_shared_cf1(row).meta; i++)
-    {
+    KRML_MAYBE_FOR2(i,
+      (size_t)0U,
+      (size_t)2U,
+      (size_t)1U,
       size_t j = i;
       const Eurydice_arr_b9 *a_element = &row->data[j];
       Eurydice_arr_b9 product = ntt_multiply_d6_ea(a_element, &r_as_ntt->data[j]);
-      add_to_ring_element_d6_a0(&result.data[i1], &product);
-    }
+      add_to_ring_element_d6_a0(&result.data[i1], &product););
     invert_ntt_montgomery_a0(&result.data[i1]);
-    add_error_reduce_d6_ea(&result.data[i1], &error_1->data[i1]);
-  }
+    add_error_reduce_d6_ea(&result.data[i1], &error_1->data[i1]););
   return result;
 }
 
@@ -7658,8 +7555,10 @@ with const generics
 static KRML_MUSTINLINE void
 compress_then_serialize_u_6d(Eurydice_arr_3d0 input, Eurydice_mut_borrow_slice_u8 out)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_shared_cf1(&input).meta; i++)
-  {
+  KRML_MAYBE_FOR2(i,
+    (size_t)0U,
+    (size_t)2U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_b9 re = input.data[i0];
     Eurydice_mut_borrow_slice_u8
@@ -7673,8 +7572,7 @@ compress_then_serialize_u_6d(Eurydice_arr_3d0 input, Eurydice_mut_borrow_slice_u
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_arr_b7 lvalue = compress_then_serialize_ring_element_u_fe(&re);
-    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_d3(&lvalue), uint8_t);
-  }
+    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_d3(&lvalue), uint8_t););
 }
 
 /**
@@ -8005,7 +7903,7 @@ deserialize_then_decompress_u_86(const Eurydice_arr_56 *ciphertext)
   (size_t
     i = (size_t)0U;
     i <
-      Eurydice_array_to_slice_shared_ee(ciphertext).meta /
+      (size_t)768U /
         (LIBCRUX_ML_KEM_CONSTANTS_COEFFICIENTS_IN_RING_ELEMENT * (size_t)10U / (size_t)8U);
     i++)
   {
@@ -9087,20 +8985,6 @@ static KRML_MUSTINLINE Eurydice_arr_1d sample_from_xof_2b(const Eurydice_arr_c3 
 }
 
 /**
-A monomorphic instance of Eurydice.array_to_slice_shared
-with types libcrux_ml_kem_polynomial_PolynomialRingElement libcrux_ml_kem_vector_portable_vector_type_PortableVector
-with const generics
-- N= 3
-*/
-static dst_ref_shared_b0 array_to_slice_shared_cf0(const Eurydice_arr_1d *a)
-{
-  dst_ref_shared_b0 lit;
-  lit.ptr = a->data;
-  lit.meta = (size_t)3U;
-  return lit;
-}
-
-/**
 A monomorphic instance of libcrux_ml_kem.matrix.sample_matrix_A
 with types libcrux_ml_kem_vector_portable_vector_type_PortableVector, libcrux_ml_kem_hash_functions_portable_PortableHash[[$3size_t]]
 with const generics
@@ -9134,8 +9018,10 @@ sample_matrix_A_2b(Eurydice_arr_dd *A_transpose, const Eurydice_arr_48 *seed, bo
       seeds.data[j].data[32U] = (uint8_t)i1;
       seeds.data[j].data[33U] = (uint8_t)j;);
     Eurydice_arr_1d sampled = sample_from_xof_2b(&seeds);
-    for (size_t i = (size_t)0U; i < array_to_slice_shared_cf0(&sampled).meta; i++)
-    {
+    KRML_MAYBE_FOR3(i,
+      (size_t)0U,
+      (size_t)3U,
+      (size_t)1U,
       size_t j = i;
       Eurydice_arr_b9 sample = sampled.data[j];
       if (transpose)
@@ -9145,8 +9031,7 @@ sample_matrix_A_2b(Eurydice_arr_dd *A_transpose, const Eurydice_arr_48 *seed, bo
       else
       {
         A_transpose->data[i1].data[j] = sample;
-      }
-    });
+      }););
 }
 
 /**
@@ -9294,8 +9179,10 @@ with const generics
 static KRML_MUSTINLINE void
 serialize_vector_1b(const Eurydice_arr_1d *key, Eurydice_mut_borrow_slice_u8 out)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_shared_cf0(key).meta; i++)
-  {
+  KRML_MAYBE_FOR3(i,
+    (size_t)0U,
+    (size_t)3U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_b9 re = key->data[i0];
     Eurydice_mut_borrow_slice_u8
@@ -9309,8 +9196,7 @@ serialize_vector_1b(const Eurydice_arr_1d *key, Eurydice_mut_borrow_slice_u8 out
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_arr_cc lvalue = serialize_uncompressed_ring_element_ea(&re);
-    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_fe(&lvalue), uint8_t);
-  }
+    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_fe(&lvalue), uint8_t););
 }
 
 /**
@@ -9898,32 +9784,6 @@ static Eurydice_arr_b9 call_mut_73_1c(void **_)
 }
 
 /**
-A monomorphic instance of Eurydice.dst_ref_shared
-with types Eurydice_arr_1d, size_t
-
-*/
-typedef struct dst_ref_shared_66_s
-{
-  const Eurydice_arr_1d *ptr;
-  size_t meta;
-}
-dst_ref_shared_66;
-
-/**
-A monomorphic instance of Eurydice.array_to_slice_shared
-with types Eurydice_arr libcrux_ml_kem_polynomial_PolynomialRingElement libcrux_ml_kem_vector_portable_vector_type_PortableVector[[$3size_t]]
-with const generics
-- N= 3
-*/
-static dst_ref_shared_66 array_to_slice_shared_b5(const Eurydice_arr_dd *a)
-{
-  dst_ref_shared_66 lit;
-  lit.ptr = a->data;
-  lit.meta = (size_t)3U;
-  return lit;
-}
-
-/**
  Given two polynomial ring elements `lhs` and `rhs`, compute the pointwise
  sum of their constituent coefficients.
 */
@@ -9936,13 +9796,14 @@ with const generics
 static KRML_MUSTINLINE void
 add_to_ring_element_1b(Eurydice_arr_b9 *myself, const Eurydice_arr_b9 *rhs)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_shared_24(&myself[0U]).meta; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (size_t)0U,
+    (size_t)16U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_e2
     uu____0 = libcrux_ml_kem_vector_portable_add_b8(myself->data[i0], &rhs->data[i0]);
-    myself->data[i0] = uu____0;
-  }
+    myself->data[i0] = uu____0;);
 }
 
 /**
@@ -9977,21 +9838,23 @@ compute_As_plus_e_1b(
   const Eurydice_arr_1d *error_as_ntt
 )
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_shared_b5(matrix_A).meta; i++)
-  {
+  KRML_MAYBE_FOR3(i,
+    (size_t)0U,
+    (size_t)3U,
+    (size_t)1U,
     size_t i0 = i;
     const Eurydice_arr_1d *row = &matrix_A->data[i0];
     Eurydice_arr_b9 uu____0 = ZERO_d6_ea();
     t_as_ntt->data[i0] = uu____0;
-    for (size_t i1 = (size_t)0U; i1 < array_to_slice_shared_cf0(row).meta; i1++)
-    {
+    KRML_MAYBE_FOR3(i1,
+      (size_t)0U,
+      (size_t)3U,
+      (size_t)1U,
       size_t j = i1;
       const Eurydice_arr_b9 *matrix_element = &row->data[j];
       Eurydice_arr_b9 product = ntt_multiply_d6_ea(matrix_element, &s_as_ntt->data[j]);
-      add_to_ring_element_d6_1b(&t_as_ntt->data[i0], &product);
-    }
-    add_standard_error_reduce_d6_ea(&t_as_ntt->data[i0], &error_as_ntt->data[i0]);
-  }
+      add_to_ring_element_d6_1b(&t_as_ntt->data[i0], &product););
+    add_standard_error_reduce_d6_ea(&t_as_ntt->data[i0], &error_as_ntt->data[i0]););
 }
 
 /**
@@ -10395,20 +10258,22 @@ compute_vector_u_1b(
     void *lvalue = (void *)0U;
     arr_struct.data[i] = call_mut_a8_1b(&lvalue););
   Eurydice_arr_1d result = arr_struct;
-  for (size_t i0 = (size_t)0U; i0 < array_to_slice_shared_b5(a_as_ntt).meta; i0++)
-  {
+  KRML_MAYBE_FOR3(i0,
+    (size_t)0U,
+    (size_t)3U,
+    (size_t)1U,
     size_t i1 = i0;
     const Eurydice_arr_1d *row = &a_as_ntt->data[i1];
-    for (size_t i = (size_t)0U; i < array_to_slice_shared_cf0(row).meta; i++)
-    {
+    KRML_MAYBE_FOR3(i,
+      (size_t)0U,
+      (size_t)3U,
+      (size_t)1U,
       size_t j = i;
       const Eurydice_arr_b9 *a_element = &row->data[j];
       Eurydice_arr_b9 product = ntt_multiply_d6_ea(a_element, &r_as_ntt->data[j]);
-      add_to_ring_element_d6_1b(&result.data[i1], &product);
-    }
+      add_to_ring_element_d6_1b(&result.data[i1], &product););
     invert_ntt_montgomery_1b(&result.data[i1]);
-    add_error_reduce_d6_ea(&result.data[i1], &error_1->data[i1]);
-  }
+    add_error_reduce_d6_ea(&result.data[i1], &error_1->data[i1]););
   return result;
 }
 
@@ -10427,8 +10292,10 @@ with const generics
 static KRML_MUSTINLINE void
 compress_then_serialize_u_43(Eurydice_arr_1d input, Eurydice_mut_borrow_slice_u8 out)
 {
-  for (size_t i = (size_t)0U; i < array_to_slice_shared_cf0(&input).meta; i++)
-  {
+  KRML_MAYBE_FOR3(i,
+    (size_t)0U,
+    (size_t)3U,
+    (size_t)1U,
     size_t i0 = i;
     Eurydice_arr_b9 re = input.data[i0];
     Eurydice_mut_borrow_slice_u8
@@ -10442,8 +10309,7 @@ compress_then_serialize_u_43(Eurydice_arr_1d input, Eurydice_mut_borrow_slice_u8
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_arr_b7 lvalue = compress_then_serialize_ring_element_u_fe(&re);
-    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_d3(&lvalue), uint8_t);
-  }
+    Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_d3(&lvalue), uint8_t););
 }
 
 /**
@@ -10739,7 +10605,7 @@ deserialize_then_decompress_u_6c(const Eurydice_arr_2c *ciphertext)
   (size_t
     i = (size_t)0U;
     i <
-      Eurydice_array_to_slice_shared_42(ciphertext).meta /
+      (size_t)1088U /
         (LIBCRUX_ML_KEM_CONSTANTS_COEFFICIENTS_IN_RING_ELEMENT * (size_t)10U / (size_t)8U);
     i++)
   {


### PR DESCRIPTION
There a lot of cascading optimizations because now a fair amount of loops have static bounds, meaning they get eligible for the KRML_FOR_XXX macros (static loop unrolling).