### PR TITLE
Fixing `check_addrof` recursion

### DIFF
--- a/lib/Cleanup2.ml
+++ b/lib/Cleanup2.ml
@@ -1169,6 +1169,8 @@ let check_addrof =
              || Krml.KString.starts_with (snd lid) "op_Bang_Star__" (* case 4, case 3 *) ->
           EAddrOf e
       | _ ->
+          (* Recursively do for the internal expression first *)
+          let e = self#visit_expr_w () e in
           if Krml.Structs.will_be_lvalue e then
             EAddrOf e
           else
@@ -1179,8 +1181,6 @@ let check_addrof =
                 Krml.Ast.meta = [ CommentBefore "original Rust expression is not an lvalue in C" ];
               }
             in
-            (* Recursively do for the internal expression *)
-            let e = self#visit_expr_w () e in
             ELet (b, e, with_type t (EAddrOf (with_type e.typ (EBound 0))))
   end
 


### PR DESCRIPTION
The pass `check_addrof` works to extract out the reference to non-left value, e.g., `&func(args)` to `let tmp = func(args) in &tmp`. But it might fail to execute recursively in some cases, e.g., `&( (&func(args))[0] )`, in this case, the `Krml.Structs.will_be_lvalue` will return `true` and hence missing the necessary transformation.

This simple fix simply move the recursive transforming to be in front of the `Krml.Structs.will_be_lvalue` check, so that it now correctly handles the cases.