### PR TITLE
Update Charon

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1778143368,
-        "narHash": "sha256-dFxx8fZxdax5cmJ/vWY4wCP/dPxi9Pm7rZ6DfB0A+KY=",
+        "lastModified": 1778253406,
+        "narHash": "sha256-2Ic8z1vLQkjxh/XkiKhgPOaMqUNrzm1IfQUie00fSq0=",
         "owner": "aeneasverif",
         "repo": "charon",
-        "rev": "769431f5789e2bc6e6e6a7f8d1c156c0cbd68cd5",
+        "rev": "ee7dbd8c304908e267c3b8fa5157ca972ddc29be",
         "type": "github"
       },
       "original": {

--- a/lib/LoadLlbc.ml
+++ b/lib/LoadLlbc.ml
@@ -1,6 +1,5 @@
 let load_file filename =
-  let ic = Yojson.Basic.from_file filename in
-  match Charon.OfJson.crate_of_json ic with
+  match Charon.OfJson.crate_of_json_file filename with
   | Ok r -> r
   | Error e ->
       Printf.fprintf stderr


### PR DESCRIPTION
Partner PR to https://github.com/AeneasVerif/charon/pull/1118; it adds a function to directly deserialize a file, while also validating the file is indeed json. This will be relevant once you start switching to the new, smaller and faster format, to get nicer errors if the file format is wrong.